### PR TITLE
Ignore also *.tar files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src/
 *.log
 *.gem
 *.tgz
+*.tar
 zenity/
 trunk/
 .npm/


### PR DESCRIPTION
For example:

```
libx32-krb5/krb5-1.12.1-signed.tar
```

Please double check and merge, thanks.
