### PR TITLE
run ./pre-commit and shellcheck on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.travis.yml
 !.git*
 pkg/
 src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+    - "3.5"
+
+## modified from https://github.com/koalaman/shellcheck/wiki/TravisCI
+
+# Use container-based infrastructure for quicker build start-up
+sudo: false
+
+addons:
+    apt:
+        sources:
+            - debian-sid    # Grab shellcheck from the Debian repo
+        packages:
+            - shellcheck
+
+script:
+    - ./pre-commit  # checking nvchecker.ini
+    - shellcheck --exclude=SC2034,SC2148,SC2154,SC2164 */PKGBUILD || true  # checking all PKGBUILDS
+    # SC2034: $VAR appears unused. Verify it or export it.
+    # SC2148: Add a shebang.
+    # SC2154: $VAR is referenced but not assigned.
+    # SC2164: Use cd $SOMEPATH || exit in case cd fails.
+
+
+matrix:
+    fast_finish: true


### PR DESCRIPTION
As discussed in #272 and #273 , we can run a travis-ci after the commit is made.
This will hopefully enforce checking and find problems earlier.

Also added shellcheck all PKGBUILDs and ignore its return value. The checking log maybe helpful.