### PR TITLE
wps-office: Add xorg-mkfontdir dependence.

### DIFF
--- a/wps-office/PKGBUILD
+++ b/wps-office/PKGBUILD
@@ -9,7 +9,9 @@ pkgdesc="Kingsoft Office (WPS Office) is an office productivity suite"
 arch=('i686' 'x86_64')
 license=("custom")
 url="http://wps-community.org/"
-depends=('fontconfig' 'libpng12' 'glib2' 'libsm' 'libxext' 'libxrender' 'libxml2' 'desktop-file-utils' 'shared-mime-info' 'xdg-utils' 'glu')
+depends=('fontconfig' 'libpng12' 'glib2' 'libsm' 'libxext' 'libxrender'
+         'libxml2' 'desktop-file-utils' 'shared-mime-info' 'xdg-utils' 'glu'
+         'xorg-mkfontdir')
 optdepends=('cups: for printing support'
             'pango: for complex (right-to-left) text support')
 conflicts=('kingsoft-office')


### PR DESCRIPTION
1. wps-office.install executes mkfontscale and mkfontdir.
2. xorg-mkfontscale provides mkfontscale.
3. xorg-mkfontdir provides mkfontdir.
4. xorg-mkfontdir depends on xorg-mkfontscale.

![qq20161219-0](https://cloud.githubusercontent.com/assets/2240638/21309248/8681cc3c-c618-11e6-8fe9-e0960310d8ae.png)
![qq20161219-1](https://cloud.githubusercontent.com/assets/2240638/21309261/95eb625a-c618-11e6-8db0-84c3b617f874.png)
