### PR TITLE
pre-commit check index tree instead of working tree

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -8,17 +8,20 @@ import sys
 import re
 from subprocess import Popen, PIPE
 from unittest import TestCase, TestSuite, TestLoader, TextTestRunner, skip
-from io import StringIO
+from io import TextIOWrapper, StringIO
 from configparser import ConfigParser
-from functools import lru_cache
 
+DIRS, FILES = None, None
 GIT_BRANCH = 'HEAD'
+
 
 def readutf8(st):
     return st.read().decode('utf-8').strip()
 
+
 def reads(st):
     return readutf8(st).strip()
+
 
 def git_write_tree_index():
     global GIT_BRANCH
@@ -26,7 +29,28 @@ def git_write_tree_index():
     with Popen(cmd, stdout=PIPE) as p:
         GIT_BRANCH = reads(p.stdout)
 
-git_write_tree_index()
+
+def git_ls_tree():
+    cmd = ['git', 'ls-tree', '-rtz', '--full-name', GIT_BRANCH]
+    ## git ls-tree
+    ## -r Recurse into sub-trees.
+    ## -t Show tree entries even when going to recurse them.
+    ## -z \0 line termination on output and do not quote filenames.
+    dirs = []
+    files = []
+    with Popen(cmd, stdout=PIPE) as p:
+        alllines = readutf8(p.stdout)
+        for line in alllines.split('\0')[:-1]: # ignore last \0
+            ## OUTPUT FORMAT
+            ## <mode> SP <type> SP <object> TAB <file>
+            first, _, path = line.partition('\t')
+            _, t, _ = first.split(' ')
+            if t == 'tree':
+                dirs.append(path)
+            elif t == 'blob':
+                files.append(path)
+        return dirs, files
+
 
 def git_open(filename):
     cmd = ['git', 'cat-file', 'blob', f'{GIT_BRANCH}:{filename}']
@@ -34,27 +58,21 @@ def git_open(filename):
         return StringIO(readutf8(p.stdout))
 
 
-@lru_cache(maxsize=1 << 16, typed=True)
 def git_listdir(path):
     cmd = ['git', 'ls-tree', '--name-only',
-           (f'{GIT_BRANCH}:{path}' if path != '.' else f'{GIT_BRANCH}')]
+           (f'{GIT_BRANCH}:{path}' if path != '.' else GIT_BRANCH)]
     with Popen(cmd, stdout=PIPE) as p:
         return reads(p.stdout).split("\n")
 
 
-@lru_cache(maxsize=1 << 16, typed=True)
 def git_isdir(path):
-    cmd = ['git', 'cat-file', '-t', f'{GIT_BRANCH}:{path}']
-    with Popen(cmd, stdout=PIPE, stderr=PIPE) as p:
-        return reads(p.stderr) == "" and reads(p.stdout) == "tree"
+    global DIRS
+    return path in DIRS
 
 
-@lru_cache(maxsize=1 << 16, typed=True)
 def git_isfile(path, name):
-    cmd = ['git', 'cat-file', '-t', f'{GIT_BRANCH}:{path}/{name}']
-    with Popen(cmd, stdout=PIPE, stderr=PIPE) as p:
-        return reads(p.stderr) == "" and reads(p.stdout) == "blob"
-
+    global FILES
+    return os.path.join(path, name) in FILES
 
 class NvcheckerSyntaxTest(TestCase):
     def test_nvchecker_ini(self):
@@ -160,6 +178,8 @@ def run_test(testcase, msg):
 
 
 if __name__ == '__main__':
+    git_write_tree_index()
+    DIRS, FILES = git_ls_tree()
     run_test(NvcheckerSyntaxTest,
              msg='\033[1;31mThere are fatal error inside repo, ' +
                  'blocking git commit. Please fix the errors and commit ' +

--- a/pre-commit
+++ b/pre-commit
@@ -19,15 +19,11 @@ def readutf8(st):
     return st.read().decode('utf-8').strip()
 
 
-def reads(st):
-    return readutf8(st).strip()
-
-
 def git_write_tree_index():
     global GIT_BRANCH
     cmd = ['git', 'write-tree']
     with Popen(cmd, stdout=PIPE) as p:
-        GIT_BRANCH = reads(p.stdout)
+        GIT_BRANCH = readutf8(p.stdout)
 
 
 def git_ls_tree():
@@ -62,7 +58,7 @@ def git_listdir(path):
     cmd = ['git', 'ls-tree', '--name-only',
            (f'{GIT_BRANCH}:{path}' if path != '.' else GIT_BRANCH)]
     with Popen(cmd, stdout=PIPE) as p:
-        return reads(p.stdout).split("\n")
+        return readutf8(p.stdout).split("\n")
 
 
 def git_isdir(path):

--- a/pre-commit
+++ b/pre-commit
@@ -12,16 +12,21 @@ from io import StringIO
 from configparser import ConfigParser
 from functools import lru_cache
 
-GIT_BRANCH = 'master'
-
+GIT_BRANCH = 'HEAD'
 
 def readutf8(st):
     return st.read().decode('utf-8').strip()
 
-
 def reads(st):
     return readutf8(st).strip()
 
+def git_write_tree_index():
+    global GIT_BRANCH
+    cmd = ['git', 'write-tree']
+    with Popen(cmd, stdout=PIPE) as p:
+        GIT_BRANCH = reads(p.stdout)
+
+git_write_tree_index()
 
 def git_open(filename):
     cmd = ['git', 'cat-file', 'blob', f'{GIT_BRANCH}:{filename}']

--- a/pre-commit
+++ b/pre-commit
@@ -6,120 +6,160 @@
 import os
 import sys
 import re
+from subprocess import Popen, PIPE
 from unittest import TestCase, TestSuite, TestLoader, TextTestRunner, skip
 from io import StringIO
 from configparser import ConfigParser
+from functools import lru_cache
+
+GIT_BRANCH = 'master'
+
+
+def readutf8(st):
+    return st.read().decode('utf-8').strip()
+
+
+def reads(st):
+    return readutf8(st).strip()
+
+
+def git_open(filename):
+    cmd = ['git', 'cat-file', 'blob', f'{GIT_BRANCH}:{filename}']
+    with Popen(cmd, stdout=PIPE) as p:
+        return StringIO(readutf8(p.stdout))
+
+
+@lru_cache(maxsize=1 << 16, typed=True)
+def git_listdir(path):
+    cmd = ['git', 'ls-tree', '--name-only',
+           (f'{GIT_BRANCH}:{path}' if path != '.' else f'{GIT_BRANCH}')]
+    with Popen(cmd, stdout=PIPE) as p:
+        return reads(p.stdout).split("\n")
+
+
+@lru_cache(maxsize=1 << 16, typed=True)
+def git_isdir(path):
+    cmd = ['git', 'cat-file', '-t', f'{GIT_BRANCH}:{path}']
+    with Popen(cmd, stdout=PIPE, stderr=PIPE) as p:
+        return reads(p.stderr) == "" and reads(p.stdout) == "tree"
+
+
+@lru_cache(maxsize=1 << 16, typed=True)
+def git_isfile(path, name):
+    cmd = ['git', 'cat-file', '-t', f'{GIT_BRANCH}:{path}/{name}']
+    with Popen(cmd, stdout=PIPE, stderr=PIPE) as p:
+        return reads(p.stderr) == "" and reads(p.stdout) == "blob"
 
 
 class NvcheckerSyntaxTest(TestCase):
-  def test_nvchecker_ini(self):
-    self.config = ConfigParser(dict_type=dict, allow_no_value=True)
-    with open('nvchecker.ini') as configfile:
-      self.config.read_file(configfile)
+    def test_nvchecker_ini(self):
+        self.config = ConfigParser(dict_type=dict, allow_no_value=True)
+        with git_open('nvchecker.ini') as configfile:
+            self.config.read_file(configfile)
 
 
 class ConfigSectionTest(TestCase):
-  def setUp(self):
-    self.item_key_regex = re.compile('([_0-9a-zA-Z]+)')
-    self.config = ConfigParser(dict_type=dict, allow_no_value=True)
-    with open('nvchecker.ini') as configfile:
-      self.config.read_file(configfile)
+    def setUp(self):
+        self.item_key_regex = re.compile('([_0-9a-zA-Z]+)')
+        self.config = ConfigParser(dict_type=dict, allow_no_value=True)
+        with git_open('nvchecker.ini') as configfile:
+            self.config.read_file(configfile)
 
-  def test_config_section(self):
-    self.assertIn("__config__", self.config,
-                  msg='nvchecker.ini has no ' +
-                      '""\033[1;31m__config__\033[m" section')
-    self.assertIn("oldver", self.config["__config__"],
-                  msg='"__config__" section has no ' +
-                      '"\033[1;31moldver\033[m" setting')
-    self.assertIn("newver", self.config["__config__"],
-                  msg='"__config__" section has no ' +
-                      '"\033[1;31mnewver\033[m" setting')
+    def test_config_section(self):
+        self.assertIn("__config__", self.config,
+                      msg='nvchecker.ini has no ' +
+                          '""\033[1;31m__config__\033[m" section')
+        self.assertIn("oldver", self.config["__config__"],
+                      msg='"__config__" section has no ' +
+                          '"\033[1;31moldver\033[m" setting')
+        self.assertIn("newver", self.config["__config__"],
+                      msg='"__config__" section has no ' +
+                          '"\033[1;31mnewver\033[m" setting')
 
-  def test_sections(self):
-    for section in self.config.sections():
-      if section == "__config__":
-        continue
-      with self.subTest(section=section):
-        self.assertTrue(os.path.isdir(section),
-                        msg=('nvchecker.ini contains ' +
-                             '"\033[1;31m{0}\033[m" section but there is no ' +
-                             '"\033[1;31m{0}\033[m" package').format(section))
-      with self.subTest(section=section):
-        self.assertGreater(len(self.config[section].items()), 0,
-                           msg=('section "\033[1;31m{0}\033[m" ' +
-                                'is empty').format(section))
-      for key, value in self.config[section].items():
-        with self.subTest(section=section, key=key, value=value):
-          self.assertTrue(self.item_key_regex.match(key),
-                          msg=('nvchecker.ini section "\033[1;31m{0}\033[m" ' +
-                               'contains ill-formed key ' +
-                               '"\033[1;31m{1}\033[m"').format(section, key))
+    def test_sections(self):
+        for section in self.config.sections():
+            if section == "__config__":
+                continue
+            with self.subTest(section=section):
+                self.assertTrue(git_isdir(section),
+                                msg=('nvchecker.ini contains ' +
+                                     '"\033[1;31m{0}\033[m" section but there is no ' +
+                                     '"\033[1;31m{0}\033[m" package').format(section))
+            with self.subTest(section=section):
+                self.assertGreater(len(self.config[section].items()), 0,
+                                   msg=('section "\033[1;31m{0}\033[m" ' +
+                                        'is empty').format(section))
+            for key, value in self.config[section].items():
+                with self.subTest(section=section, key=key, value=value):
+                    self.assertTrue(self.item_key_regex.match(key),
+                                    msg=('nvchecker.ini section "\033[1;31m{0}\033[m" ' +
+                                         'contains ill-formed key ' +
+                                         '"\033[1;31m{1}\033[m"').format(section, key))
 
-  @skip("226 packages violating this")
-  def test_have_lilac_py(self):
-    for section in self.config.sections():
-      if "manual" not in self.config[section]:
-        with self.subTest(section=section):
-          self.assertTrue(os.path.isfile(os.path.join(section, "lilac.py")),
-                          msg=('package "\033[1;31m{0}\033[m" does not ' +
-                               'have lilac.py').format(section))
+    @skip("226 packages violating this")
+    def test_have_lilac_py(self):
+        for section in self.config.sections():
+            if "manual" not in self.config[section]:
+                with self.subTest(section=section):
+                    self.assertTrue(git_isfile(section, "lilac.py"),
+                                    msg=('package "\033[1;31m{0}\033[m" does not ' +
+                                         'have lilac.py').format(section))
 
-  def test_folders(self):
-    for package in os.listdir('.'):
-      if not os.path.isdir(package):
-        continue
-      if package[0] == '.':
-        continue
-      with self.subTest(package=package):
-        self.assertTrue(os.path.isfile(os.path.join(package, "PKGBUILD")),
-                        msg=('package "\033[1;31m{0}\033[m" does not ' +
-                             'have PKGBUILD').format(package))
+    def test_folders(self):
+        for package in git_listdir('.'):
+            if not git_isdir(package):
+                continue
+            if package[0] == '.':
+                continue
+            with self.subTest(package=package):
+                self.assertTrue(git_isfile(package, "PKGBUILD"),
+                                msg=('package "\033[1;31m{0}\033[m" does not ' +
+                                     'have PKGBUILD').format(package))
 
-  def test_lilac_py_has_nvchecker_config(self):
-    for package in os.listdir('.'):
-      if not os.path.isdir(package):
-        continue
-      if package[0] == '.':
-        continue
-      if not os.path.exists(os.path.join(package, 'lilac.py')):
-        continue
+    def test_lilac_py_has_nvchecker_config(self):
+        for package in git_listdir('.'):
+            if not git_isdir(package):
+                continue
+            if package[0] == '.':
+                continue
+            if not git_isfile(package, 'lilac.py'):
+                continue
 
-      with self.subTest(package=package):
-        self.assertIn(package, self.config,
-                      msg=('package "\033[1;31m{0}\033[m" is not in ' +
-                           '"nvchecker.ini"').format(package))
+            with self.subTest(package=package):
+                self.assertIn(package, self.config,
+                              msg=('package "\033[1;31m{0}\033[m" is not in ' +
+                                   '"nvchecker.ini"').format(package))
 
-
-  @skip("37 packages violating this")
-  def test_folders_in_nvchecker(self):
-    for package in os.listdir('.'):
-      if not os.path.isdir(package):
-        continue
-      if package[0] == '.':
-        continue
-      with self.subTest(package=package):
-        self.assertIn(package, self.config,
-                      msg=('package "\033[1;31m{0}\033[m" is not in ' +
-                           '"nvchecker.ini"').format(package))
+    @skip("37 packages violating this")
+    def test_folders_in_nvchecker(self):
+        for package in git_listdir('.'):
+            if not git_isdir(package):
+                continue
+            if package[0] == '.':
+                continue
+            with self.subTest(package=package):
+                self.assertIn(package, self.config,
+                              msg=('package "\033[1;31m{0}\033[m" is not in ' +
+                                   '"nvchecker.ini"').format(package))
 
 
 def run_test(testcase, msg):
-  output = StringIO()
-  suite = TestLoader().loadTestsFromTestCase(testcase)
-  runner = TextTestRunner(output, verbosity=0)
-  results = runner.run(suite)
-  if not results.wasSuccessful():
-    print(output.getvalue())
-    print(msg.format(len(results.failures)))
-    sys.exit(1)
+    output = StringIO()
+    suite = TestLoader().loadTestsFromTestCase(testcase)
+    runner = TextTestRunner(output, verbosity=0)
+    results = runner.run(suite)
+    if not results.wasSuccessful():
+        print(output.getvalue())
+        print(msg.format(len(results.failures)))
+        sys.exit(1)
+
 
 if __name__ == '__main__':
-  run_test(NvcheckerSyntaxTest,
-           msg='\033[1;31mThere are fatal error inside repo, ' +
-               'blocking git commit. Please fix the errors and commit ' +
-               'again\033[m')
-  run_test(ConfigSectionTest,
-           msg=('\033[1;31mThere are {0} error(s) inside repo, ' +
-                'blocking git commit. Please fix the errors and commit ' +
-                'again\033[m'))
+    run_test(NvcheckerSyntaxTest,
+             msg='\033[1;31mThere are fatal error inside repo, ' +
+                 'blocking git commit. Please fix the errors and commit ' +
+                 'again\033[m')
+    run_test(ConfigSectionTest,
+             msg=('\033[1;31mThere are {0} error(s) inside repo, ' +
+                  'blocking git commit. Please fix the errors and commit ' +
+                  'again\033[m'))


### PR DESCRIPTION
This change on pre-commit hook tries to check the index tree (files already added by `git add`) instead of the working tree. So that it will not see the ignored/removed files (as they not being in the index tree), and will detect mistakes like forgetting to add modified nvchecker.ini.

The down side: `git commit` will take more than 5 secs on my SSD machine, because all the `popen("git", ...)` costs. I already tried `lru_cache` to save some time. It was more than 10s before using lru_cache.

Should we use this new hook or stick to the old one (which is more quicker) ?