### PR TITLE
add rust-nightly-wasm32-unknown-unknown

### DIFF
--- a/rust-nightly/lilac.py
+++ b/rust-nightly/lilac.py
@@ -23,6 +23,7 @@ STDS = [
   'x86_64-pc-windows-gnu',
   'asmjs-unknown-emscripten',
   'wasm32-unknown-emscripten',
+  'wasm32-unknown-unknown',
   'aarch64-linux-android',
 ]
 
@@ -36,6 +37,7 @@ toolchain = {
   'i686-unknown-linux-gnu': ['gcc-multilib'],
   'asmjs-unknown-emscripten': ['emsdk', 'emscripten'],
   'wasm32-unknown-emscripten': ['emsdk', 'emscripten'],
+  'wasm32-unknown-unknown': [],
   'aarch64-linux-android': ['android-ndk'],
 }
 


### PR DESCRIPTION
[std: Add a new wasm32-unknown-unknown target](https://github.com/rust-lang/rust/pull/45905)
[rustbuild: Enable WebAssembly backend by default](https://github.com/rust-lang/rust/pull/46115)

I'm not sure whether this back end has additional dependencies, so just left it empty.