### PR TITLE
webkitgtk: update from AUR; fixed building with enchant 2.x

### DIFF
--- a/webkitgtk/PKGBUILD
+++ b/webkitgtk/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=webkitgtk
 pkgname=(webkitgtk webkitgtk2)
 pkgver=2.4.11
-pkgrel=6
+pkgrel=7
 epoch=3
 pkgdesc="Legacy Web content engine"
 arch=(i686 x86_64)
@@ -20,10 +20,12 @@ options=(!emptydirs)
 install=webkitgtk.install
 source=(https://webkitgtk.org/releases/$pkgbase-${pkgver}.tar.xz
         webkitgtk-2.4.9-abs.patch
-        icu59.patch)
+        icu59.patch
+        enchant-2.x.patch)
 sha256sums=('588aea051bfbacced27fdfe0335a957dca839ebe36aa548df39c7bbafdb65bf7'
             'ec294bbb5588a1802a68e3615c6718486b22f922645c5fef686d3d103014bf70'
-            'eb791b9c8dcb84996904846dedf8c3ddf1a5fde32330177f3f0071510bd8ca6d')
+            'eb791b9c8dcb84996904846dedf8c3ddf1a5fde32330177f3f0071510bd8ca6d'
+            '81a4ad1c921bece16edb9a3cb187096fd8f336db8b89114356119a86f26e3d6d')
 
 prepare() {
   mkdir build-gtk{,2} path
@@ -32,6 +34,7 @@ prepare() {
   cd $pkgbase-$pkgver
   patch -Np1 -i ../webkitgtk-2.4.9-abs.patch
   patch -Np1 -i ../icu59.patch
+  patch -Np1 -i ../enchant-2.x.patch
 }
 
 _build() (
@@ -42,6 +45,9 @@ _build() (
 
   CXXFLAGS+=" -fno-delete-null-pointer-checks"
   CFLAGS+=" -fno-delete-null-pointer-checks"
+
+  CFLAGS+=" -Wno-expansion-to-defined"
+  CXXFLAGS+=" -Wno-expansion-to-defined"
 
   ../$pkgbase-$pkgver/configure --prefix=/usr \
     --libexecdir=/usr/lib/webkit${_ver} \

--- a/webkitgtk/enchant-2.x.patch
+++ b/webkitgtk/enchant-2.x.patch
@@ -1,0 +1,11 @@
+--- webkitgtk-2.4.9/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp.orig	2017-12-06 14:59:40.768262788 -0500
++++ webkitgtk-2.4.9/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp	2017-12-06 15:03:10.000000000 -0500
+@@ -128,7 +128,7 @@
+         for (i = 0; i < numberOfSuggestions; i++)
+             guesses.append(String::fromUTF8(suggestions[i]));
+ 
+-        enchant_dict_free_suggestions(*iter, suggestions);
++        enchant_dict_free_string_list(*iter, suggestions);
+     }
+ 
+     return guesses;


### PR DESCRIPTION
This is basically the same as https://aur.archlinux.org/cgit/aur.git/commit/?h=webkitgtk&id=42cc417a1edb3f36eef984a12f9f059f242ea19b except the ```epoch``` part.

cc @colinkeenan