### PR TITLE
Fix websocketd lilac.py  _G.newver.lstrip('v')

### DIFF
--- a/websocketd/lilac.py
+++ b/websocketd/lilac.py
@@ -9,7 +9,7 @@ from lilaclib import *
 build_prefix = 'extra-x86_64'
 
 def pre_build():
-  update_pkgver_and_pkgrel(_G.newver)
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
 
 def post_build():
   git_add_files('PKGBUILD')


### PR DESCRIPTION
把多余的 `v` 裁掉