### PR TITLE
ccls-git: track github instead of aur

### DIFF
--- a/ccls-git/lilac.py
+++ b/ccls-git/lilac.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3
-#
-# This file is the most simple lilac.py file,
-# and it suits for most packages in AUR.
-#
-
 from lilaclib import *
 
 build_prefix = 'extra-x86_64'
-pre_build = aur_pre_build
-post_build = aur_post_build
+
+pre_build = vcs_update
+
+def post_build():
+  git_add_files('PKGBUILD')
+  git_commit()
 
 if __name__ == '__main__':
   single_main()

--- a/nvchecker.ini
+++ b/nvchecker.ini
@@ -1604,7 +1604,7 @@ aur =
 
 # MaskRay <i@maskray.me> {{{1
 [ccls-git]
-aur=
+github = MaskRay/ccls
 
 [python-telethon]
 pypi = Telethon


### PR DESCRIPTION
Fix #854