### PR TITLE
mpv-git: update PKGBUILD, shaderc available in AUR

### DIFF
--- a/mpv-git/PKGBUILD
+++ b/mpv-git/PKGBUILD
@@ -28,7 +28,7 @@ _opt_features=(
   wayland
 
   #vulkan
-  #shaderc # preferred SPIR-V compiler; only available as -git from AUR
+  #shaderc # preferred SPIR-V compiler; available from AUR
 
   uchardet
   rubberband
@@ -120,8 +120,7 @@ for feature in "${_opt_features[@]}"; do
       depends+=('vulkan-icd-loader')
       ;;
     shaderc)
-      #depends+=('shaderc')
-      depends+=('shaderc-git')
+      depends+=('shaderc')
       ;;
     uchardet|rubberband)
       depends+=("$feature")


### PR DESCRIPTION
In October, Google released version 2018.0 of `shaderc` (see https://github.com/google/shaderc/releases), and now AUR has `shaderc` package which builds v2018.0 (https://aur.archlinux.org/packages/shaderc/). `shaderc-git` package has also updated so that it provides `shaderc`.