### PR TITLE
virtualbox-ext-oracle: make it follow AUR

### DIFF
--- a/nvchecker.ini
+++ b/nvchecker.ini
@@ -310,7 +310,7 @@ pypi = uniout
 github = dubiousjim/dcron
 
 [virtualbox-ext-oracle]
-pacman = virtualbox
+aur =
 
 [beautifuldnsd]
 github = programmervy/beautifuldnsd


### PR DESCRIPTION
This package was tracking local pacman database. If local databases are
not up-to-date, this package will not be updated either. This is the
case on build.archlinuxcn.org as of now.

Closes: https://github.com/archlinuxcn/repo/issues/918