### PR TITLE
tree-wide: fix incorrect vcs specs in update_on

### DIFF
--- a/beignet-git/lilac.yaml
+++ b/beignet-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: beignet-git
+  - vcs

--- a/devtools-cn-git/lilac.yaml
+++ b/devtools-cn-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: devtools-cn-git
+  - vcs

--- a/emacs-julia-mode-git/lilac.yaml
+++ b/emacs-julia-mode-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: emacs-julia-mode-git
+  - vcs

--- a/emacs-llvm-mode-git/lilac.yaml
+++ b/emacs-llvm-mode-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: emacs-llvm-mode-git
+  - vcs

--- a/emacs-markdown-mode-git/lilac.yaml
+++ b/emacs-markdown-mode-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: emacs-markdown-mode-git
+  - vcs

--- a/julia-pkg-scripts/lilac.yaml
+++ b/julia-pkg-scripts/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: julia-pkg-scripts
+  - vcs

--- a/libunwind-git/lilac.yaml
+++ b/libunwind-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: libunwind-git
+  - vcs

--- a/libutf8proc-git/lilac.yaml
+++ b/libutf8proc-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: libutf8proc-git
+  - vcs

--- a/oce-git/lilac.yaml
+++ b/oce-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: oce-git
+  - vcs

--- a/openblas-lapack-git/lilac.yaml
+++ b/openblas-lapack-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: openblas-lapack-git
+  - vcs

--- a/openlibm-git/lilac.yaml
+++ b/openlibm-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: openlibm-git
+  - vcs

--- a/openspecfun-git/lilac.yaml
+++ b/openspecfun-git/lilac.yaml
@@ -8,7 +8,7 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: openspecfun-git
+  - vcs
 
 depends:
   - openlibm-git

--- a/rr-git/lilac.yaml
+++ b/rr-git/lilac.yaml
@@ -8,4 +8,4 @@ build_prefix: multilib
 pre_build: vcs_update
 
 update_on:
-  - vcs: rr-git
+  - vcs

--- a/scribus-svn/lilac.yaml
+++ b/scribus-svn/lilac.yaml
@@ -9,4 +9,4 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: scribus-svn
+  - vcs

--- a/spice-vdagent-git/lilac.yaml
+++ b/spice-vdagent-git/lilac.yaml
@@ -9,4 +9,4 @@ build_prefix: archlinuxcn-x86_64
 pre_build: vcs_update
 
 update_on:
-  - vcs: spice-vdagent-git
+  - vcs

--- a/virtualbox-svn/lilac.yaml
+++ b/virtualbox-svn/lilac.yaml
@@ -9,4 +9,4 @@ build_prefix: multilib
 pre_build: vcs_update
 
 update_on:
-  - vcs: virtualbox-svn
+  - vcs


### PR DESCRIPTION
Most likely they are victims of a nvchecker2yaml bug.