### PR TITLE
Add missed depends of systemtap: readline, nspr

### DIFF
--- a/archlinuxcn/systemtap/PKGBUILD
+++ b/archlinuxcn/systemtap/PKGBUILD
@@ -3,12 +3,12 @@
 # Contributor : dront78 <dront78@gmail.com>
 pkgname=systemtap
 pkgver=4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="provides infrastructure to simplify the gathering of information about the running system."
 url="http://sourceware.org/systemtap/"
 arch=('x86_64' 'i686')
 license=('GPL')
-depends=('elfutils' 'nss' 'python2' 'json-c' 'avahi')
+depends=('elfutils' 'nss' 'python2' 'json-c' 'avahi' 'readline' 'nspr')
 makedepends=('python2-setuptools' 'xmlto' 'cpio')
 optdepends=('sqlite3: for storing results in a database')
 source=("${pkgname}-${pkgver}.tar.gz::https://sourceware.org/systemtap/ftp/releases/${pkgname}-${pkgver}.tar.gz"

--- a/archlinuxcn/systemtap/lilac.yaml
+++ b/archlinuxcn/systemtap/lilac.yaml
@@ -7,4 +7,7 @@ maintainers:
 build_prefix: extra-x86_64
 
 update_on:
-  - manual: 4.0-1
+  - manual: 4.0-2
+  - archpkg: readline
+    from_pattern: ^(\d+)\..*
+    to_pattern: \1


### PR DESCRIPTION
Since readline is upgraded to 8.0.0, libreadline.so.7 does not exist now. So systemtap needs to be rebuilt.

However my question is, if a package depends on readline, and if readline upgrades, will other packages depend on it be rebuilt automatically?