### PR TITLE
amarok: 修复启动时提示mysql嵌入式服务器启动失败，更改依赖libssh-gnutls为libssh

### DIFF
--- a/archlinuxcn/amarok/PKGBUILD
+++ b/archlinuxcn/amarok/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=amarok
 pkgver=2.9.0.r337.eb9706eaee
-pkgrel=1
+pkgrel=2
 pkgdesc="The powerful music player for KDE"
 arch=("x86_64")
 url="http://${pkgname}.kde.org/"
@@ -16,8 +16,10 @@ makedepends=("extra-cmake-modules" "gdk-pixbuf2" "git" "knotifyconfig" "libgpod"
 optdepends=("ifuse: support for Apple iPod Touch and iPhone"
             "loudmouth: backend needed by mp3tunes for syncing")
 _commit="eb9706eaee14e07d894cf2ad442268a6f62d915a"
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/KDE/${pkgname}/archive/${_commit}.tar.gz")
-sha256sums=("83e1039a98e8185d3c4c81fcb296f4e35a1e31df2c993df961f8579399a63da4")
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/KDE/${pkgname}/archive/${_commit}.tar.gz"
+        "amarok.patch")
+sha256sums=("83e1039a98e8185d3c4c81fcb296f4e35a1e31df2c993df961f8579399a63da4"
+            "3f947cd9b49a4062cebe610592d651c2a7d60277b6350dde4a2756b5d5166b6f")
 
 #git describe --long --tags 2> /dev/null | sed "s/^[A-Za-z\.\-]*//;s/\([^-]*-\)g/r\1/;s/-/./g"
 #source=("http://download.kde.org/stable/${pkgname}/${pkgver}/src/${pkgname}-${pkgver}.tar.xz"{,.sig})
@@ -25,6 +27,9 @@ sha256sums=("83e1039a98e8185d3c4c81fcb296f4e35a1e31df2c993df961f8579399a63da4")
 
 prepare() {
   mkdir -p "${srcdir}/${pkgname}-${_commit}/build"
+
+  cd "${srcdir}/${pkgname}-${_commit}"
+  patch -Np1 -i "${srcdir}/amarok.patch"
 }
 
 build() {

--- a/archlinuxcn/amarok/PKGBUILD
+++ b/archlinuxcn/amarok/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="The powerful music player for KDE"
 arch=("x86_64")
 url="http://${pkgname}.kde.org/"
 license=("FDL" "GPL2" "LGPL2.1")
-depends=("kcmutils" "kdnssd" "kirigami2" "knewstuff" "ktexteditor" "libgpod" "liblastfm-qt5" "libmtp" "libmygpo-qt5" "libofa" "libssh-gnutls" "mariadb" "phonon-qt5" "qt5-webengine" "taglib-extras" "threadweaver")
+depends=("kcmutils" "kdnssd" "kirigami2" "knewstuff" "ktexteditor" "libgpod" "liblastfm-qt5" "libmtp" "libmygpo-qt5" "libofa" "libssh" "mariadb" "phonon-qt5" "qt5-webengine" "taglib-extras" "threadweaver")
 makedepends=("extra-cmake-modules" "gdk-pixbuf2" "git" "knotifyconfig" "libgpod" "libmtp" "libmygpo-qt5" "loudmouth")
 optdepends=("ifuse: support for Apple iPod Touch and iPhone"
             "loudmouth: backend needed by mp3tunes for syncing")

--- a/archlinuxcn/amarok/amarok.patch
+++ b/archlinuxcn/amarok/amarok.patch
@@ -1,0 +1,21 @@
+diff -ura amarok-eb9706eaee14e07d894cf2ad442268a6f62d915a/cmake/modules/FindMySQL.cmake amarok-diff/cmake/modules/FindMySQL.cmake
+--- amarok-eb9706eaee14e07d894cf2ad442268a6f62d915a/cmake/modules/FindMySQL.cmake	2019-01-12 04:54:33.000000000 +0800
++++ amarok-diff/cmake/modules/FindMySQL.cmake	2019-01-27 21:52:42.770416475 +0800
+@@ -42,7 +42,16 @@
+         # At least on OpenSUSE --libmysql-libs doesn't exist, so we just use
+         # MYSQL_LIBRARIES for that. We'll see if that's enough when testing
+         # below.
+-        set(MYSQL_EMBEDDED_LIBRARIES ${MYSQL_LIBRARIES})
++        # mysql-config removed --libmysql-libs, but amarok need libmysqld other
++        # than libmysqlclient to run mysql embedded server.
++        find_library(MYSQL_EMBEDDED_LIBRARIES NAMES mysqld libmysqld
++            PATHS
++                $ENV{MYSQL_DIR}/libmysql_r/.libs
++                $ENV{MYSQL_DIR}/lib
++                $ENV{MYSQL_DIR}/lib/mysql
++            PATH_SUFFIXES
++                mysql
++        )
+     else()
+         set(MYSQL_EMBEDDED_LIBRARIES ${MC_MYSQL_EMBEDDED_LIBRARIES})
+     endif()


### PR DESCRIPTION
1. 由于mariadb的mysql_config不再提供--libmysqld-libs参数，按照旧的FindMySQL.cmake导致cmake会去链接libmysqlclient，而不是libmysqld，这样的话会导致amarok启动时出现mysql embedded server启动失败的错误 ，进而无法正常使用该功能。

2. 如果是因为[这里](https://www.libssh.org/archive/libssh/2018-08/0000032.html)提到的问题，导致需要依赖libssh-gnutls。经过测试发现目前已经没有这个问题了，依赖libssh也能正常工作。
