### PR TITLE
[fixed] litecli: use extra-x86_64 instead of archlinuxcn-x86_64

### DIFF
--- a/archlinuxcn/litecli/lilac.yaml
+++ b/archlinuxcn/litecli/lilac.yaml
@@ -1,7 +1,10 @@
 maintainers:
   - github: masakichi
 
-build_prefix: archlinuxcn-x86_64
+build_prefix: extra-x86_64
+
+depends:
+  - python-cli_helpers
 
 update_on:
   - aur: litecli


### PR DESCRIPTION
#1073 