### PR TITLE
add package: kicad-i18n-git

### DIFF
--- a/archlinuxcn/kicad-i18n-git/PKGBUILD
+++ b/archlinuxcn/kicad-i18n-git/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Edward Pacman <edward at edward-p dot xyz>
+# Maintainer: lilac <lilac@build.archlinuxcn.org>
+
+pkgname=kicad-i18n-git
+pkgver=r1633.5292d3b
+pkgrel=1
+pkgdesc="Translations for KiCad source code."
+arch=('i686' 'x86_64')
+url="http://kicad-pcb.org/"
+license=('GPL')
+depends=('kicad-git')
+makedepends=('cmake' 'git' 'gettext')
+source=("${pkgname}"'::git+https://github.com/kicad/kicad-i18n')
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${pkgname}"
+  printf "r%s.%s" "$(git rev-list HEAD --count --first-parent)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}"
+  mkdir -p build
+  cd build
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}"
+  cd build
+  make DESTDIR="${pkgdir}" install
+}

--- a/archlinuxcn/kicad-i18n-git/lilac.py
+++ b/archlinuxcn/kicad-i18n-git/lilac.py
@@ -1,0 +1,17 @@
+# Trimmed lilac.py
+#!/usr/bin/env python3
+#
+# This file is the most simple lilac.py file,
+# and it suits for most packages in AUR.
+#
+
+from lilaclib import *
+
+
+def post_build():
+    update_aur_repo()
+    git_add_files("PKGBUILD")
+    git_commit()
+
+#if __name__ == '__main__':
+#  single_main()

--- a/archlinuxcn/kicad-i18n-git/lilac.yaml
+++ b/archlinuxcn/kicad-i18n-git/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: edward-p
+
+build_prefix: extra-x86_64
+
+pre_build: vcs_update
+
+update_on:
+  - github: kicad/kicad-i18n
+
+repo_depends:
+  - kicad-git


### PR DESCRIPTION
Add package `kicad-i18n-git` : Translations for KiCad source code.
Added lilac as Co-Maintainer of [kicad-i18n-git on AUR](https://aur.archlinux.org/packages/kicad-i18n-git).