### PR TITLE
jdownloader2: remove an unused file

### DIFF
--- a/archlinuxcn/jdownloader2/jdownloader
+++ b/archlinuxcn/jdownloader2/jdownloader
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-exec bash /usr/bin/JDownloader "$@"
-


### PR DESCRIPTION
Both JDownloader and jdownloader are in the repo, which confuses case-insensitive file systems like APFS. (I sync the archlinuxcn repo across all my devices, so this repo appears on both EXT4 and APFS.)