### PR TITLE
Make lilac.py optional

### DIFF
--- a/archlinuxcn/abiword-gtk2/lilac.yaml
+++ b/archlinuxcn/abiword-gtk2/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: abiword-gtk2
+
+managed: false

--- a/archlinuxcn/angrysearch/lilac.yaml
+++ b/archlinuxcn/angrysearch/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: angrysearch
+
+managed: false

--- a/archlinuxcn/apache-tools/lilac.yaml
+++ b/archlinuxcn/apache-tools/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: apache-tools
+
+managed: false

--- a/archlinuxcn/assimp-net/lilac.yaml
+++ b/archlinuxcn/assimp-net/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: assimp-net
+
+managed: false

--- a/archlinuxcn/binfmt-wine/lilac.yaml
+++ b/archlinuxcn/binfmt-wine/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: binfmt-wine
+
+managed: false

--- a/archlinuxcn/brother-hl2140/lilac.yaml
+++ b/archlinuxcn/brother-hl2140/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: brother-hl2140
+
+managed: false

--- a/archlinuxcn/cla/lilac.yaml
+++ b/archlinuxcn/cla/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: cla
+
+managed: false

--- a/archlinuxcn/clup/lilac.yaml
+++ b/archlinuxcn/clup/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: clup
+
+managed: false

--- a/archlinuxcn/codecs64/lilac.yaml
+++ b/archlinuxcn/codecs64/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: codecs64
+
+managed: false

--- a/archlinuxcn/dcron-git/lilac.yaml
+++ b/archlinuxcn/dcron-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: dubiousjim/dcron
+
+managed: false

--- a/archlinuxcn/drive/lilac.yaml
+++ b/archlinuxcn/drive/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: drive
+
+managed: false

--- a/archlinuxcn/freerapid/lilac.yaml
+++ b/archlinuxcn/freerapid/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: freerapid
+
+managed: false

--- a/archlinuxcn/glib/lilac.yaml
+++ b/archlinuxcn/glib/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: glib
+
+managed: false

--- a/archlinuxcn/gnome-search-tool-no-nautilus/lilac.yaml
+++ b/archlinuxcn/gnome-search-tool-no-nautilus/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - archpkg: gnome-search-tool
+
+managed: false

--- a/archlinuxcn/gnome-shell-extension-gsconnect-git/lilac.yaml
+++ b/archlinuxcn/gnome-shell-extension-gsconnect-git/lilac.yaml
@@ -4,3 +4,5 @@ build_prefix: extra-x86_64
 pre_build: vcs_update
 update_on:
   - github: andyholmes/gnome-shell-extension-gsconnect
+
+managed: false

--- a/archlinuxcn/gottet/lilac.yaml
+++ b/archlinuxcn/gottet/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: gottet
+
+managed: false

--- a/archlinuxcn/grub-git/lilac.yaml
+++ b/archlinuxcn/grub-git/lilac.yaml
@@ -10,3 +10,5 @@ pre_build: vcs_update
 
 update_on:
   - vcs: git://git.savannah.gnu.org/grub.git 
+
+managed: false

--- a/archlinuxcn/gtk-theme-arc-git/lilac.yaml
+++ b/archlinuxcn/gtk-theme-arc-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: horst3180/Arc-theme
+
+managed: false

--- a/archlinuxcn/hal-flash-git/lilac.yaml
+++ b/archlinuxcn/hal-flash-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: cshorler/hal-flash
+
+managed: false

--- a/archlinuxcn/hydroxygen-iconset/lilac.yaml
+++ b/archlinuxcn/hydroxygen-iconset/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: hydroxygen-iconset
+
+managed: false

--- a/archlinuxcn/lib32-oxygen-gtk2/lilac.yaml
+++ b/archlinuxcn/lib32-oxygen-gtk2/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: lib32-oxygen-gtk2
+
+managed: false

--- a/archlinuxcn/lumina-desktop/lilac.yaml
+++ b/archlinuxcn/lumina-desktop/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: lumina-desktop
+
+managed: false

--- a/archlinuxcn/monogame-git/lilac.yaml
+++ b/archlinuxcn/monogame-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: monogame-git
+
+managed: false

--- a/archlinuxcn/nant/lilac.yaml
+++ b/archlinuxcn/nant/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: nant
+
+managed: false

--- a/archlinuxcn/nautilus-data/lilac.yaml
+++ b/archlinuxcn/nautilus-data/lilac.yaml
@@ -6,3 +6,5 @@ maintainers:
 update_on:
   - url: http://www.ubuntuupdates.org/package/core/trusty/main/base/nautilus-data
     regex: nautilus-data_(\d+.\d+.\d+-\dubuntu.+)_all.deb
+
+managed: false

--- a/archlinuxcn/newrelic-php53/lilac.yaml
+++ b/archlinuxcn/newrelic-php53/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: newrelic-php53
+
+managed: false

--- a/archlinuxcn/newrelic-sysmond/lilac.yaml
+++ b/archlinuxcn/newrelic-sysmond/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: newrelic-sysmond
+
+managed: false

--- a/archlinuxcn/nixnote2/lilac.yaml
+++ b/archlinuxcn/nixnote2/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: nixnote2
+
+managed: false

--- a/archlinuxcn/nodejs-tiddlywiki/lilac.yaml
+++ b/archlinuxcn/nodejs-tiddlywiki/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - npm: tiddlywiki
+
+managed: false

--- a/archlinuxcn/openvpn-obfs/lilac.yaml
+++ b/archlinuxcn/openvpn-obfs/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: openvpn-obfs
+
+managed: false

--- a/archlinuxcn/package-query/lilac.yaml
+++ b/archlinuxcn/package-query/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: package-query
+
+managed: false

--- a/archlinuxcn/packettracer/lilac.yaml
+++ b/archlinuxcn/packettracer/lilac.yaml
@@ -8,3 +8,5 @@ build_prefix: extra-x86_64
 
 update_on:
   - manual: 7.2.1
+
+managed: false

--- a/archlinuxcn/pacnew-auto-git/lilac.yaml
+++ b/archlinuxcn/pacnew-auto-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: joanrieu/pacnew-auto
+
+managed: false

--- a/archlinuxcn/plasma5-applets-active-window-control-git/lilac.yaml
+++ b/archlinuxcn/plasma5-applets-active-window-control-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: kotelnik/plasma-applet-active-window-control
+
+managed: false

--- a/archlinuxcn/python2-bjoern/lilac.yaml
+++ b/archlinuxcn/python2-bjoern/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-bjoern
+
+managed: false

--- a/archlinuxcn/python2-dict2xml/lilac.yaml
+++ b/archlinuxcn/python2-dict2xml/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-dict2xml
+
+managed: false

--- a/archlinuxcn/python2-gcm/lilac.yaml
+++ b/archlinuxcn/python2-gcm/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-gcm
+
+managed: false

--- a/archlinuxcn/python2-newrelic/lilac.yaml
+++ b/archlinuxcn/python2-newrelic/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-newrelic
+
+managed: false

--- a/archlinuxcn/python2-pika/lilac.yaml
+++ b/archlinuxcn/python2-pika/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-pika
+
+managed: false

--- a/archlinuxcn/python2-pypdf2/lilac.yaml
+++ b/archlinuxcn/python2-pypdf2/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-pypdf2
+
+managed: false

--- a/archlinuxcn/python2-topia.termextract/lilac.yaml
+++ b/archlinuxcn/python2-topia.termextract/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: python2-topia.termextract
+
+managed: false

--- a/archlinuxcn/qarma-git/lilac.yaml
+++ b/archlinuxcn/qarma-git/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - github: luebking/qarma
+
+managed: false

--- a/archlinuxcn/qgroundcontrol/lilac.yaml
+++ b/archlinuxcn/qgroundcontrol/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: qgroundcontrol
+
+managed: false

--- a/archlinuxcn/qtadb/lilac.yaml
+++ b/archlinuxcn/qtadb/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: qtadb
+
+managed: false

--- a/archlinuxcn/ruby-hiera/lilac.yaml
+++ b/archlinuxcn/ruby-hiera/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: ruby-hiera
+
+managed: false

--- a/archlinuxcn/scilab/lilac.yaml
+++ b/archlinuxcn/scilab/lilac.yaml
@@ -22,3 +22,5 @@ repo_depends:
 
 update_on:
   - manual: 6.0.1-5
+
+managed: false

--- a/archlinuxcn/sfml1.6/lilac.yaml
+++ b/archlinuxcn/sfml1.6/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: sfml1.6
+
+managed: false

--- a/archlinuxcn/shadowvpn/lilac.yaml
+++ b/archlinuxcn/shadowvpn/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: shadowvpn
+
+managed: false

--- a/archlinuxcn/shine/lilac.yaml
+++ b/archlinuxcn/shine/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: shine
+
+managed: false

--- a/archlinuxcn/silentcast/lilac.yaml
+++ b/archlinuxcn/silentcast/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: silentcast
+
+managed: false

--- a/archlinuxcn/simple-mtpfs/lilac.yaml
+++ b/archlinuxcn/simple-mtpfs/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: simple-mtpfs
+
+managed: false

--- a/archlinuxcn/sniproxy/lilac.yaml
+++ b/archlinuxcn/sniproxy/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: sniproxy
+
+managed: false

--- a/archlinuxcn/sublime-text-imfix/lilac.yaml
+++ b/archlinuxcn/sublime-text-imfix/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: sublime-text-imfix
+
+managed: false

--- a/archlinuxcn/tchrome/lilac.yaml
+++ b/archlinuxcn/tchrome/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: tchrome
+
+managed: false

--- a/archlinuxcn/terminus-font-ttf/lilac.yaml
+++ b/archlinuxcn/terminus-font-ttf/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: terminus-font-ttf
+
+managed: false

--- a/archlinuxcn/terminusmod/lilac.yaml
+++ b/archlinuxcn/terminusmod/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: terminusmod
+
+managed: false

--- a/archlinuxcn/vertex-themes/lilac.yaml
+++ b/archlinuxcn/vertex-themes/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: vertex-themes
+
+managed: false

--- a/archlinuxcn/w3watch/lilac.yaml
+++ b/archlinuxcn/w3watch/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: w3watch
+
+managed: false

--- a/archlinuxcn/wallch/lilac.yaml
+++ b/archlinuxcn/wallch/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: wallch
+
+managed: false

--- a/archlinuxcn/xavs/lilac.yaml
+++ b/archlinuxcn/xavs/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xavs
+
+managed: false

--- a/archlinuxcn/xfce4-linelight-plugin/lilac.yaml
+++ b/archlinuxcn/xfce4-linelight-plugin/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xfce4-linelight-plugin
+
+managed: false

--- a/archlinuxcn/xfce4-macmenu-plugin/lilac.yaml
+++ b/archlinuxcn/xfce4-macmenu-plugin/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xfce4-macmenu-plugin
+
+managed: false

--- a/archlinuxcn/xfce4-soundmenu-plugin/lilac.yaml
+++ b/archlinuxcn/xfce4-soundmenu-plugin/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xfce4-soundmenu-plugin
+
+managed: false

--- a/archlinuxcn/xfdashboard/lilac.yaml
+++ b/archlinuxcn/xfdashboard/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xfdashboard
+
+managed: false

--- a/archlinuxcn/xinput_calibrator/lilac.yaml
+++ b/archlinuxcn/xinput_calibrator/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: xinput_calibrator
+
+managed: false

--- a/archlinuxcn/yaourt/lilac.yaml
+++ b/archlinuxcn/yaourt/lilac.yaml
@@ -5,3 +5,5 @@ maintainers:
 
 update_on:
   - aur: yaourt
+
+managed: false

--- a/lilac-yaml-schema.yaml
+++ b/lilac-yaml-schema.yaml
@@ -71,5 +71,9 @@ properties:
             - github
             - email
     minItems: 1
+  managed:
+    description: Whether the package should be built by lilac or not
+    type: boolean
+    default: true
 required:
   - maintainers


### PR DESCRIPTION
Part of #990.

I noticed that all touched packages have `update_on`. I think qt4 packages should be managed (https://github.com/archlinuxcn/repo/issues/1154). Please check other packages, thanks!