### PR TITLE
Sync lilac-yaml-schema.yaml from archlinuxcn/lilac 

### DIFF
--- a/lilac-yaml-schema.yaml
+++ b/lilac-yaml-schema.yaml
@@ -46,7 +46,7 @@ properties:
         - type: object
           description: nvchecker configuration section
         - type: string
-          description: Shorthand for simple check sources (e.g. "aur"). Must be the first one if used.
+          description: Shorthand for simple check sources (e.g. "aur").
     minItems: 1
   maintainers:
     description: List of maintainers for receiving email notifications


### PR DESCRIPTION
No longer true after https://github.com/archlinuxcn/lilac/pull/114.