### PR TITLE
[AddPkg] multimc5: A custom launcher for Minecraft

### DIFF
--- a/archlinuxcn/multimc5/PKGBUILD
+++ b/archlinuxcn/multimc5/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: xiretza <xiretza+aur@gmail.com>
+# Contributor: vorpalblade77@gmail.com
+# Contributor: b.klettbach@gmail.com
+
+pkgname=multimc5
+pkgver=0.6.5
+pkgrel=1
+__pkgver_libnbtplusplus=multimc-0.6.1
+__pkgver_quazip=multimc-3
+pkgdesc="Minecraft launcher with ability to manage multiple instances."
+arch=('i686' 'x86_64')
+url="http://multimc.org/"
+license=('Apache')
+depends=('zlib' 'libgl' 'qt5-base' 'qt5-x11extras' 'java-runtime' 'qt5-svg' 'xorg-xrandr')
+provides=('multimc')
+conflicts=('multimc')
+makedepends=('cmake' 'java-environment')
+optdepends=('mcedit: Allows editing of minecraft worlds')
+
+source=("https://github.com/MultiMC/MultiMC5/archive/${pkgver}.tar.gz"
+        "https://github.com/MultiMC/libnbtplusplus/archive/${__pkgver_libnbtplusplus}.tar.gz"
+        "https://github.com/MultiMC/quazip/archive/${__pkgver_quazip}.tar.gz"
+        "quazip-fix-build-with-qt-511.patch"
+        "quazip-fix-build-with-Werror.patch"
+)
+sha512sums=('472c676223c180e176e1430d880cc7449118c7af501bb5354286158151b513b0b510c9c5ba1f4cf5e49ea46863b582dbf8ade84e1ec6b7716b297cbec9582082'
+            '81a1640a069d88df7ba0abf72089aecbe1e9d791c88acaaa7e70c8f0bcd0512cf8698178342657e363524ce8488dd072368a0aa8cc091a24912d6f8b6b0f4f2d'
+            '2e9074203c67bc7ad98621c551047e5367f06e54cacfecc755a5bf2c9f99266eab42ad972f86ae28ed7e1507f6d27d8d2680a87ce9fd5b1e93a18bcb627ec3f0'
+            'ca7a350bdeecf65dbca7de8d6912c935c6ba603edcddcd4ffe71d8997e50e4046335dde6d1d7c629d35025073d18be4d112a960d43a8801de979687bc26e46d4'
+            '6aad02ddb97ecbcd89f27db49a6925bf5e69881e7ab5258630be3b336b4b1510873aa2e1d327a2f74e48394f6aec5090b6b909aa5657cd29880680d17580203d')
+prepare() {
+  cd "${srcdir}/MultiMC5-${pkgver}"
+  patch -p1 < "${srcdir}/quazip-fix-build-with-Werror.patch"
+  
+  rmdir "libraries/libnbtplusplus"
+  rmdir "libraries/quazip"
+  cp --recursive "${srcdir}/libnbtplusplus-${__pkgver_libnbtplusplus}/" \
+    "libraries/libnbtplusplus"
+  cp --recursive "${srcdir}/quazip-${__pkgver_quazip}/" \
+    "libraries/quazip"
+
+  cd "libraries/quazip"
+  # https://github.com/MultiMC/quazip/pull/1
+  patch -p1 < "${srcdir}/quazip-fix-build-with-qt-511.patch"
+}
+
+build() {
+  cd "${srcdir}/MultiMC5-${pkgver}"
+  mkdir -p build
+
+  cd build
+  cmake -DCMAKE_BUILD_TYPE=Release \
+	  -DMultiMC_UPDATER=OFF \
+	  -DCMAKE_INSTALL_PREFIX="/usr" \
+	  -DMultiMC_LAYOUT=lin-system \
+	  ..
+  make
+}
+
+check() {
+  cd "${srcdir}/MultiMC5-${pkgver}/build"
+  make test
+}
+
+package() {
+  cd "${srcdir}/MultiMC5-${pkgver}/build"
+  make install DESTDIR="${pkgdir}"
+  install -D "${srcdir}/MultiMC5-${pkgver}/application/resources/multimc/scalable/multimc.svg" "${pkgdir}/usr/share/pixmaps/multimc.svg"
+  install -D "${srcdir}/MultiMC5-${pkgver}/application/package/linux/multimc.desktop" "${pkgdir}/usr/share/applications/multimc.desktop"
+  install -D "${srcdir}/MultiMC5-${pkgver}/build/libMultiMC_quazip.so" "${pkgdir}/usr/lib/libMultiMC_quazip.so"
+  install -D "${srcdir}/MultiMC5-${pkgver}/build/libMultiMC_nbt++.so" "${pkgdir}/usr/lib/libMultiMC_nbt++.so"
+}

--- a/archlinuxcn/multimc5/lilac.yaml
+++ b/archlinuxcn/multimc5/lilac.yaml
@@ -1,0 +1,7 @@
+maintainers:
+  - github: Rasphino
+
+build_prefix: extra-x86_64
+
+update_on:
+  - manual: 0.6.5

--- a/archlinuxcn/multimc5/quazip-fix-build-with-Werror.patch
+++ b/archlinuxcn/multimc5/quazip-fix-build-with-Werror.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt   2019-02-21 07:45:36.000000000 +0800
++++ b/CMakeLists.txt.1 2019-05-23 19:29:47.021951275 +0800
+@@ -32,7 +32,7 @@
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_C_STANDARD 11)
+ include(GenerateExportHeader)
+-set(CMAKE_CXX_FLAGS " -Wall -pedantic -Werror -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
++set(CMAKE_CXX_FLAGS " -Wall -pedantic -Werror -Wno-error=deprecated-declarations -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
+ if(UNIX AND APPLE)
+     set(CMAKE_CXX_FLAGS " -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+ endif()

--- a/archlinuxcn/multimc5/quazip-fix-build-with-qt-511.patch
+++ b/archlinuxcn/multimc5/quazip-fix-build-with-qt-511.patch
@@ -1,0 +1,33 @@
+From 469b97b618314ec009a37cad22e9d2541d6481f7 Mon Sep 17 00:00:00 2001
+From: Sergey Shatunov <me@prok.pw>
+Date: Fri, 1 Jun 2018 21:07:13 +0700
+Subject: [PATCH] Fix build with Qt 5.11+
+
+---
+ CMakeLists.txt | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 376583c..7c0c6eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,10 +44,9 @@ endif()
+ 
+ add_library(MultiMC_quazip SHARED ${QUAZIP_SRC})
+ target_include_directories(MultiMC_quazip PUBLIC "quazip" "${CMAKE_CURRENT_BINARY_DIR}" PRIVATE ${ZLIB_INCLUDE_DIRS})
+-target_link_libraries(MultiMC_quazip ${ZLIB_LIBRARIES})
++target_link_libraries(MultiMC_quazip Qt5::Core ${ZLIB_LIBRARIES})
+ target_compile_definitions(MultiMC_quazip PRIVATE "-DQUAZIP_BUILD")
+ set_target_properties(MultiMC_quazip PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN 1)
+-qt5_use_modules(MultiMC_quazip Core)
+ 
+ # Install it
+ install(
+@@ -84,6 +83,5 @@ set(QUAZIP_TEST_SRC
+ )
+ 
+ add_executable(MultiMC_quazip_test ${QUAZIP_TEST_SRC})
+-target_link_libraries(MultiMC_quazip_test MultiMC_quazip)
+-qt5_use_modules(MultiMC_quazip_test Network Test)
++target_link_libraries(MultiMC_quazip_test MultiMC_quazip Qt5::Network Qt5::Test)
+ add_test(NAME quazip_testsuite COMMAND MultiMC_quazip_test)


### PR DESCRIPTION
[multimc5](https://github.com/MultiMC/MultiMC5/tree/stable) is a custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once.

The PKGBUILD in AUR cannot build, thus I make a patch.