### PR TITLE
解决了网易云音乐无法输入中文的问题

### DIFF
--- a/archlinuxcn/netease-cloud-music/PKGBUILD
+++ b/archlinuxcn/netease-cloud-music/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Peter Cai <peter at typeblog dot net>
+# Contributor: Mike Tong <3344907598 [AT] qq.com>
 pkgname=netease-cloud-music
 pkgver=1.2.1
 _pkgdate=20190428
@@ -7,7 +8,7 @@ pkgdesc="Netease Cloud Music, converted from .deb package"
 arch=("x86_64")
 url="http://music.163.com/"
 license=('custom')
-depends=()
+depends=('qcef')
 source=(
 	"http://d1.music.126.net/dmusic/netease-cloud-music_${pkgver}_amd64_ubuntu_${_pkgdate}.deb"
 	"http://music.163.com/html/web2/service.html"
@@ -17,6 +18,14 @@ md5sums=('1f47c7dc3d9ce46da8099e539ee8a74d'
 
 package() {
   cd ${srcdir}
-  tar -xvf data.tar.xz -C ${pkgdir}
+  tar -xvf data.tar.xz
+  mkdir ${pkgdir}/opt
+  mkdir ${pkgdir}/opt/netease
+  mkdir ${pkgdir}/opt/netease/netease-cloud-music
+  cp ${srcdir}/opt/netease/netease-cloud-music/netease-cloud-music ${pkgdir}/opt/netease/netease-cloud-music
+  cp ${srcdir}/opt/netease/netease-cloud-music/netease-cloud-music.bash ${pkgdir}/opt/netease/netease-cloud-music
+  cp -r ${srcdir}/usr ${pkgdir}
+  sed -i "3,5d" ${pkgdir}/opt/netease/netease-cloud-music/netease-cloud-music.bash
+  sed -i "2a\export XDG_CURRENT_DESKTOP=DDE" ${pkgdir}/opt/netease/netease-cloud-music/netease-cloud-music.bash
   install -D -m644 service.html ${pkgdir}/usr/share/licenses/$pkgname/license.html
 }

--- a/archlinuxcn/netease-cloud-music/PKGBUILD
+++ b/archlinuxcn/netease-cloud-music/PKGBUILD
@@ -3,12 +3,12 @@
 pkgname=netease-cloud-music
 pkgver=1.2.1
 _pkgdate=20190428
-pkgrel=1
+pkgrel=2
 pkgdesc="Netease Cloud Music, converted from .deb package"
 arch=("x86_64")
 url="http://music.163.com/"
 license=('custom')
-depends=('qcef')
+depends=('qcef' 'vlc')
 source=(
 	"http://d1.music.126.net/dmusic/netease-cloud-music_${pkgver}_amd64_ubuntu_${_pkgdate}.deb"
 	"http://music.163.com/html/web2/service.html"
@@ -19,9 +19,7 @@ md5sums=('1f47c7dc3d9ce46da8099e539ee8a74d'
 package() {
   cd ${srcdir}
   tar -xvf data.tar.xz
-  mkdir ${pkgdir}/opt
-  mkdir ${pkgdir}/opt/netease
-  mkdir ${pkgdir}/opt/netease/netease-cloud-music
+  install -d ${pkgdir}/opt/netease/netease-cloud-music
   cp ${srcdir}/opt/netease/netease-cloud-music/netease-cloud-music ${pkgdir}/opt/netease/netease-cloud-music
   cp ${srcdir}/opt/netease/netease-cloud-music/netease-cloud-music.bash ${pkgdir}/opt/netease/netease-cloud-music
   cp -r ${srcdir}/usr ${pkgdir}


### PR DESCRIPTION
使用Arch系的用户可能会发现，网易云音乐在Arch系无法输入中文。
至于为什么呢？原理我说一下：网易云音乐linux版本是使用qecf这个qt库来开发的。但是在ubuntu上，没有这一个依赖包，于是网易云音乐官方就在ubuntu版直接内置qcef这个库。这也是为什么网易云音乐的linux版分为ubuntu版和deepin版，其实可以看做带qecf版和不带qecf版，因为deepin的软件仓库自带qcef。 但是，网易云音乐的ubuntu版内置的qcef在arch系的发行版无法输入中文，但是archlinux的软件仓库自带这个。我解决的思路就是不让这玩意使用自带的qcef，使用archlinux自己的qcef。这样子，就可以在网易云音乐输入中文了。
我修改了PKGBUILD，专门解决这个问题，并且得益于此，安装包体积从300M缩小到5M。
不过，我修改了下启动器，让这玩意识别桌面环境为dde。这样可以解决kde托盘无法右键和一些窗口管理器出现双重标题栏的问题。