### PR TITLE
vidalia: declare qt4 dependency

### DIFF
--- a/archlinuxcn/vidalia/lilac.yaml
+++ b/archlinuxcn/vidalia/lilac.yaml
@@ -9,5 +9,8 @@ pre_build: aur_pre_build
 
 post_build: aur_post_build
 
+repo_depends:
+  - qt4
+
 update_on:
   - aur: vidalia


### PR DESCRIPTION
Closes: #1154 - this is the only remaining package in need of an action

PS: I didn't test this change myself.