### PR TITLE
addpkg: code-transparent

### DIFF
--- a/archlinuxcn/code-transparent/PKGBUILD
+++ b/archlinuxcn/code-transparent/PKGBUILD
@@ -1,0 +1,157 @@
+# Maintainer: frantic1048 <i@frantic1048.com>
+# Contributor: Filipe Laíns (FFY00) <lains@archlinux.org>
+# Contributor: Michael Hansen <zrax0111 gmail com>
+# Contributor: Francisco Magalhães <franmagneto gmail com>
+
+pkgname=code-transparent
+_pkgname=code
+pkgdesc='The Open Source build of Visual Studio Code (vscode) editor - with transparency enabled.'
+# Important: Remember to check https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites for target node version
+# NodeJS versioning cheatsheet:
+#   - carbon: 8
+#   - dubnium: 10
+# Important: Remember to check https://github.com/microsoft/vscode/blob/master/.yarnrc (choose correct tag) for target electron version
+pkgver=1.39.2
+pkgrel=1
+arch=('x86_64')
+url='https://github.com/microsoft/vscode'
+license=('MIT')
+depends=('electron4' 'libsecret' 'libx11' 'libxkbfile' 'ripgrep')
+optdepends=('bash-completion: Bash completions'
+            'zsh-completions: ZSH completitons')
+makedepends=('git' 'gulp' 'npm' 'python2' 'yarn' 'nodejs-lts-dubnium')
+conflicts=('code')
+provides=('code')
+install='code-transparent.install'
+source=("$_pkgname::git+https://github.com/Microsoft/vscode.git#tag=$pkgver"
+        'code.js'
+        'code.sh'
+        'product_json.diff'
+        'enable-proposed-apis.diff'
+        'transparent.diff')
+sha512sums=('SKIP'
+            '814c9554427183cd893a33cd2cbe91f6e0ea71921ef0717c86217b1d3058d265f9ff7a9ace3e7b76f122e60b7686475cf4d999e581a1845face3033afb9f745f'
+            'dfd9ca38e6510c9ad59fb24c1141fdfeb136f457392aee79b0bc2ff378c4c54d81a06728ba3ec4039d57dfcd730c26686585de9b4032a21ee8151a4f05195c15'
+            '8ec47e497287d67f37e7b669af416f43d5cdbd4574892867d7b95996ef5de53640b5bc919b06b177e1fd91cb005579d6ed0c17325117b9914ba7cf28f5f06e40'
+            'b267dcedaf51067a782d0f14007663b706973c1538f7fb91f093475134c2145fd0ffd5ed2b47ad7f01c6167a78a4af285d2818d7850fc67a7f7a473324824664'
+            '09e417a861d8c84855714253a65aeb954575a1ca51f5ef0fc6bc2aaa6fee9ba507325ce9ed2d450ba070d461456ef5fa60993ac68fc89f21c7d2f9ebe6631266')
+
+# Even though we don't officially support other archs, let's
+# allow the user to use this PKGBUILD to compile the package
+# for his architecture
+case "$CARCH" in
+  i686)
+    _vscode_arch=ia32
+    ;;
+  x86_64)
+    _vscode_arch=x64
+    ;;
+  armv7h)
+    _vscode_arch=arm
+    ;;
+  *)
+    # Needed for mksrcinfo
+    _vscode_arch=DUMMY
+    ;;
+esac
+
+prepare() {
+  cd $_pkgname
+
+  # This patch no longer contains proprietary modifications.
+  # See https://github.com/Microsoft/vscode/issues/31168 for details.
+  patch -p0 < ../product_json.diff
+
+  # enable window transparency
+  patch -p1 <../transparent.diff
+
+  # Set the commit and build date
+  local _commit=$(git rev-parse HEAD)
+  local _datestamp=$(date -u -Is | sed 's/\+00:00/Z/')
+  sed -e "s/@COMMIT@/$_commit/" -e "s/@DATE@/$_datestamp/" -i product.json
+
+  # See https://github.com/MicrosoftDocs/live-share/issues/262 for details
+  # Also, https://github.com/microsoft/vscode/issues/48946
+  patch -p1 < ../enable-proposed-apis.diff
+
+  # Build native modules for system electron
+  local _target=$(</usr/lib/electron4/version)
+  sed -i "s/^target .*/target \"${_target//v/}\"/" .yarnrc
+
+  # Patch appdata and desktop file
+  sed -i 's|/usr/share/@@NAME@@/@@NAME@@|@@NAME@@|g
+          s|@@NAME_SHORT@@|Code|g
+          s|@@NAME_LONG@@|Code - OSS|g
+          s|@@NAME@@|code-oss|g
+          s|@@ICON@@|code-oss|g
+          s|@@EXEC@@|/usr/bin/code-oss|g
+          s|@@LICENSE@@|MIT|g
+          s|@@URLPROTOCOL@@|vscode|g
+          s|inode/directory;||' resources/linux/code{.appdata.xml,.desktop,-url-handler.desktop}
+
+  # Add missing exectable name to bash completion
+  sed -i 's|complete -F _code code|complete -F _code code code-oss|' resources/completions/bash/code
+  # Create new zsh completion file for our binary
+  cp resources/completions/zsh/_code resources/completions/zsh/_code-oss
+  sed -i 's|#compdef code|#compdef code code-oss|' resources/completions/zsh/_code-oss
+
+  # Fix bin path
+  sed -i "s|return path.join(path.dirname(execPath), 'bin', \`\${product.applicationName}\`);|return '/usr/bin/code';|g
+          s|return path.join(appRoot, 'scripts', 'code-cli.sh');|return '/usr/bin/code';|g" \
+          src/vs/platform/environment/node/environmentService.ts
+}
+
+build() {
+  # https://github.com/mapbox/node-sqlite3/issues/1044
+  mkdir -p path
+  ln -sf /usr/bin/python2 path/python
+  export PATH="$PWD/path:$PATH"
+
+  cd $_pkgname
+
+  yarn install --arch=$_vscode_arch
+
+  # The default memory limit may be too low for current versions of node
+  # to successfully build vscode. Change it if this number still doesn't
+  # work for your system.
+  mem_limit="--max_old_space_size=8192"
+
+  if ! /usr/bin/node $mem_limit /usr/bin/gulp vscode-linux-$_vscode_arch-min
+  then
+      echo
+      echo "*** NOTE: If the build failed due to running out of file handles (EMFILE),"
+      echo "*** you will need to raise your max open file limit."
+      echo "*** You can check this for more information on how to increase this limit:"
+      echo "***    https://ro-che.info/articles/2017-03-26-increase-open-files-limit"
+      exit 1
+  fi
+}
+
+package() {
+  # Install resource files
+  install -dm 755 "$pkgdir"/usr/lib/$_pkgname
+  cp -r --no-preserve=ownership --preserve=mode VSCode-linux-$_vscode_arch/resources/app/* "$pkgdir"/usr/lib/$_pkgname/
+
+  # replace statically included binary with system copy
+  ln -sf /usr/bin/rg "$pkgdir"/usr/lib/code/node_modules.asar.unpacked/vscode-ripgrep/bin/rg
+
+  # Install binary
+  install -Dm 755 code.sh "$pkgdir"/usr/bin/code-oss
+  install -Dm 755 code.js "$pkgdir"/usr/lib/$_pkgname/code.js
+  ln -sf /usr/bin/code-oss "$pkgdir"/usr/bin/code
+
+  # Install appdata and desktop file
+  install -Dm 644 $_pkgname/resources/linux/code.appdata.xml "$pkgdir"/usr/share/metainfo/code-oss.appdata.xml
+  install -Dm 644 $_pkgname/resources/linux/code.desktop "$pkgdir"/usr/share/applications/code-oss.desktop
+  install -Dm 644 $_pkgname/resources/linux/code-url-handler.desktop "$pkgdir"/usr/share/applications/code-oss-url-handler.desktop
+  install -Dm 644 VSCode-linux-$_vscode_arch/resources/app/resources/linux/code.png "$pkgdir"/usr/share/pixmaps/code-oss.png
+
+  # Install bash and zsh completions
+  install -Dm 644 $_pkgname/resources/completions/bash/code "$pkgdir"/usr/share/bash-completion/completions/code-oss
+  ln -s code-oss "$pkgdir"/usr/share/bash-completion/completions/code
+  install -Dm 644 $_pkgname/resources/completions/zsh/_code-oss "$pkgdir"/usr/share/zsh/site-functions/_code-oss
+
+  # Install license files
+  install -Dm 644 VSCode-linux-$_vscode_arch/resources/app/LICENSE.txt "$pkgdir"/usr/share/licenses/$_pkgname/LICENSE
+  install -Dm 644 VSCode-linux-$_vscode_arch/resources/app/ThirdPartyNotices.txt "$pkgdir"/usr/share/licenses/$_pkgname/ThirdPartyNotices.txt
+}

--- a/archlinuxcn/code-transparent/code-liveshare.diff
+++ b/archlinuxcn/code-transparent/code-liveshare.diff
@@ -1,0 +1,12 @@
+diff --git a/product.json b/product.json
+index b250c66fc4..8a9befcfbb 100644
+--- a/product.json
++++ b/product.json
+@@ -19,6 +19,7 @@
+ 	"reportIssueUrl": "https://github.com/Microsoft/vscode/issues/new",
+ 	"urlProtocol": "code-oss",
+ 	"extensionAllowedProposedApi": [
++		"ms-vsliveshare.vsliveshare",
+ 		"ms-vscode.references-view"
+ 	],
+ 	"quality": "stable",

--- a/archlinuxcn/code-transparent/code-transparent.install
+++ b/archlinuxcn/code-transparent/code-transparent.install
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# MEMO: https://wiki.archlinux.org/index.php/PKGBUILD#install
+post_install() {
+  echo '
+Troubleshooting
+------------------------
+
+If Code is not shown transparent:
+
+  1. Ensure color setting of Code is configured
+     with transparent colors. (See "Config" section below)
+  2. Ensure your compositor has transparency enabled.
+  3. Open a second Code window. (Sometimes works)
+
+
+
+Config
+------------------------
+
+Although Code is transparency-enabled, 
+Code needs to be configured with transparent
+colors to see the transparency effect.
+
+You can configure each color by yourself,
+or start with an already transparent color config.
+
+Consider copying below color config to your Code settings.json:
+
+  "workbench.colorCustomizations": {
+    // non-standard, transparency patched version only
+    "workbench.background": "#00000080",
+
+    // VSC colors
+    // ref: https://code.visualstudio.com/api/references/theme-color
+    "activityBar.background": "#46575e5e",
+    "button.background": "#00000040",
+    "button.hoverBackground": "#00000080",
+
+    "editor.background": "#00000029",
+    "editor.lineHighlightBackground": "#FFFFFF15",
+    "editorGroupHeader.tabsBackground": "#00000050",
+    "tab.activeBackground": "#00000080",
+    "tab.inactiveBackground": "#00000020",
+    "tab.border": "#00000000",
+
+    "list.activeSelectionBackground": "#00000040",
+    "list.hoverBackground": "#00000040",
+    "list.inactiveSelectionBackground": "#00000040",
+
+    "panel.background": "#00000080",
+    "panel.border": "#00000000",
+
+    "sideBar.background": "#00000080",
+    "sideBarSectionHeader.background": "#00000000",
+
+    "statusBar.background": "#00000080",
+    "statusBar.noFolderBackground": "#00000080",
+    "terminal.background": "#0000",
+    "titleBar.activeBackground": "#00000030"
+  },
+'
+}

--- a/archlinuxcn/code-transparent/code.js
+++ b/archlinuxcn/code-transparent/code.js
@@ -1,0 +1,29 @@
+#!/usr/bin/electron
+
+const name = 'code-oss';
+
+const app = require('electron').app;
+const path = require('path');
+const fs = require("fs");
+
+// Change command name.
+const fd = fs.openSync("/proc/self/comm", fs.constants.O_WRONLY);
+fs.writeSync(fd, name);
+fs.closeSync(fd);
+
+// Remove first command line argument (/usr/lib/code/code.js). - We call the CLI file first
+process.argv.splice(0, 1);
+
+// Set application paths.
+const appPath = __dirname;
+const packageJson = require(path.join(appPath, 'package.json'));
+app.setAppPath(appPath);
+app.setDesktopName(name + '.desktop');
+app.setName(name);
+app.setPath('userCache', path.join(app.getPath('cache'), name));
+app.setPath('userData', path.join(app.getPath('appData'), name));
+app.setVersion(packageJson.version);
+
+// Run the application.
+require('module')._load(appPath, module, true);
+

--- a/archlinuxcn/code-transparent/code.sh
+++ b/archlinuxcn/code-transparent/code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ELECTRON_RUN_AS_NODE=1 exec electron4 /usr/lib/code/out/cli.js /usr/lib/code/code.js "$@"

--- a/archlinuxcn/code-transparent/enable-proposed-apis.diff
+++ b/archlinuxcn/code-transparent/enable-proposed-apis.diff
@@ -1,0 +1,13 @@
+diff --git a/product.json b/product.json
+index b250c66fc4..8a9befcfbb 100644
+--- a/product.json
++++ b/product.json
+@@ -19,6 +19,8 @@
+ 	"reportIssueUrl": "https://github.com/Microsoft/vscode/issues/new",
+ 	"urlProtocol": "code-oss",
+ 	"extensionAllowedProposedApi": [
++		"ms-vsliveshare.vsliveshare",
++		"ms-vscode-remote.remote-ssh",
+ 		"ms-vscode.references-view"
+ 	],
+ 	"quality": "stable",

--- a/archlinuxcn/code-transparent/lilac.yaml
+++ b/archlinuxcn/code-transparent/lilac.yaml
@@ -1,0 +1,11 @@
+maintainers:
+  - github: frantic1048
+
+build_prefix: extra-x86_64
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - aur: code-transparent

--- a/archlinuxcn/code-transparent/product_json.diff
+++ b/archlinuxcn/code-transparent/product_json.diff
@@ -1,0 +1,20 @@
+--- product.json	2019-04-06 13:26:49.879655883 +0100
++++ product.json	2019-04-06 13:26:37.399656243 +0100
+@@ -1,4 +1,17 @@
+ {
++	"quality": "stable",
++	"extensionsGallery": {
++		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
++		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
++		"itemUrl": "https://marketplace.visualstudio.com/items"
++	},
++	"documentationUrl": "https://code.visualstudio.com/docs",
++	"requestFeatureUrl": "https://github.com/Microsoft/vscode/issues",
++	"introductoryVideosUrl": "https://go.microsoft.com/fwlink/?linkid=832146",
++	"tipsAndTricksUrl": "https://go.microsoft.com/fwlink/?linkid=852118",
++	"keyboardShortcutsUrlLinux": "https://go.microsoft.com/fwlink/?linkid=832144",
++	"commit": "@COMMIT@",
++	"date": "@DATE@",
+ 	"nameShort": "Code - OSS",
+ 	"nameLong": "Code - OSS",
+ 	"applicationName": "code-oss",

--- a/archlinuxcn/code-transparent/transparent.diff
+++ b/archlinuxcn/code-transparent/transparent.diff
@@ -1,0 +1,78 @@
+
+diff -ru a/src/main.js b/src/main.js
+--- a/src/main.js	2019-10-21 15:16:40.287933959 +0800
++++ b/src/main.js	2019-10-21 14:24:16.491539975 +0800
+@@ -142,6 +142,9 @@
+ 	// Force pre-Chrome-60 color profile handling (for https://github.com/Microsoft/vscode/issues/51791)
+ 	app.commandLine.appendSwitch('disable-color-correct-rendering');
+ 
++	// enable transparent
++	app.commandLine.appendSwitch('enable-transparent-visuals');
++
+ 	// Support JS Flags
+ 	const jsFlags = getJSFlags(cliArgs);
+ 	if (jsFlags) {
+diff -ru a/src/vs/code/electron-main/window.ts b/src/vs/code/electron-main/window.ts
+--- a/src/vs/code/electron-main/window.ts	2019-10-21 15:16:40.304601230 +0800
++++ b/src/vs/code/electron-main/window.ts	2019-10-21 15:14:08.935088758 +0800
+@@ -121,7 +121,8 @@
+ 			height: this.windowState.height,
+ 			x: this.windowState.x,
+ 			y: this.windowState.y,
+-			backgroundColor: this.themeMainService.getBackgroundColor(),
++			transparent: true,
++			backgroundColor: '#00000000' || this.themeMainService.getBackgroundColor(),
+ 			minWidth: CodeWindow.MIN_WIDTH,
+ 			minHeight: CodeWindow.MIN_HEIGHT,
+ 			show: !isFullscreenOrMaximized,
+diff -ru a/src/vs/workbench/common/theme.ts b/src/vs/workbench/common/theme.ts
+--- a/src/vs/workbench/common/theme.ts	2019-10-21 23:14:46.424664135 +0800
++++ b/src/vs/workbench/common/theme.ts	2019-10-21 23:15:24.641792763 +0800
+@@ -7,20 +7,25 @@
+ import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground } from 'vs/platform/theme/common/colorRegistry';
+ import { Disposable } from 'vs/base/common/lifecycle';
+ import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
+-import { Color } from 'vs/base/common/color';
++import { Color, RGBA } from 'vs/base/common/color';
+
+-// < --- Workbench (not customizable) --- >
++// < --- Workbench --- >
+
+-export function WORKBENCH_BACKGROUND(theme: ITheme): Color {
+-	switch (theme.type) {
+-		case 'dark':
+-			return Color.fromHex('#252526');
+-		case 'light':
+-			return Color.fromHex('#F3F3F3');
+-		default:
+-			return Color.fromHex('#000000');
+-	}
+-}
++export const WORKBENCH_BACKGROUND = (theme: ITheme) =>
++	theme.getColor(
++		registerColor(
++			'workbench.background',
++			{
++				dark: '#252526',
++				light: '#F3F3F3',
++				hc: '#000000'
++			},
++			nls.localize(
++				'workbenchBackground',
++				'Top-level background color. Not seen unless other elements have a transparent color.'
++			)
++		)
++	) || new Color(new RGBA(0, 0, 0, 0));
+
+ // < --- Tabs --- >
+
+--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts	2019-10-22 10:40:29.212561275 +0800
++++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts	2019-10-22 10:41:08.469016308 +0800
+@@ -469,6 +469,7 @@
+ 			macOptionIsMeta: config.macOptionIsMeta,
+ 			macOptionClickForcesSelection: config.macOptionClickForcesSelection,
+ 			rightClickSelectsWord: config.rightClickBehavior === 'selectWord',
++			allowTransparency: true,
+ 			// TODO: Guess whether to use canvas or dom better
+ 			rendererType: config.rendererType === 'auto' ? 'canvas' : config.rendererType
+ 		});


### PR DESCRIPTION
这个包是我维护的同名 AUR 包（增加了透明支持的 VS Code），它是基于 Arch 官方源的 code 包基础上加了 patch，所以理论上检查 out of date 是根据 archpkg: code 来， rebuild 是根据 aur 来。

看了 https://archlinuxcn.github.io/lilac/ 描述第一个是用于更新检查的，但是头一次这么用希望确认一下没有搞错（
