### PR TITLE
add alttab-git

### DIFF
--- a/archlinuxcn/alttab-git/PKGBUILD
+++ b/archlinuxcn/alttab-git/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Jay Ta'ala <jay@jaytaala.com>
+# Contributor: Maciej Mazur <mamciek@gmail.com>
+
+pkgname=alttab-git
+_name=alttab
+pkgver=v1.4.0.16.g6ff9d46
+pkgrel=1
+pkgdesc="The task switcher for minimalistic window managers or standalone X11 session"
+url="https://github.com/sagb/alttab"
+license=('GPL3')
+arch=('i686' 'x86_64')
+depends=('libx11' 'libxmu' 'libxft' 'libxrender' 'libxrandr' 'libpng' 'uthash')
+makedepends=('autoconf' 'automake')
+source=("git+https://github.com/sagb/alttab.git#branch=master")
+sha1sums=('SKIP')
+
+pkgver() {
+	cd "$_name"
+	git describe --tags |sed 's/-/./g'
+}
+
+build() {
+	pwd
+	ls -al
+	cd "$_name"
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	pwd
+	ls -al
+	cd "$_name"
+	make DESTDIR="$pkgdir/" install
+}

--- a/archlinuxcn/alttab-git/lilac.yaml
+++ b/archlinuxcn/alttab-git/lilac.yaml
@@ -1,0 +1,8 @@
+maintainers:
+- github: masakichi
+
+update_on:
+- github: sagb/alttab
+
+pre_build: vcs_update
+post_build: git_pkgbuild_commit


### PR DESCRIPTION
配合 i3wm 用还是挺不错的。

我目前用的一个配置：
![image](https://user-images.githubusercontent.com/1995921/68669495-04aa8380-058e-11ea-871b-35ea3faa721d.png)


`exec_always alttab -mk Super_L -fg "#d58681" -bg "#4a4a4a" -frame "#eb564d" -t 256x384 -i 256x256 -d 1`