### PR TITLE
Add lilac.yaml to remaining packages

### DIFF
--- a/archlinuxcn/arm-linux-gnueabihf-binutils/lilac.yaml
+++ b/archlinuxcn/arm-linux-gnueabihf-binutils/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/arm-linux-gnueabihf-glibc/lilac.yaml
+++ b/archlinuxcn/arm-linux-gnueabihf-glibc/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/arm-linux-gnueabihf-linux-api-headers/lilac.yaml
+++ b/archlinuxcn/arm-linux-gnueabihf-linux-api-headers/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/auracle-git/lilac.yaml
+++ b/archlinuxcn/auracle-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/coccinelle/lilac.yaml
+++ b/archlinuxcn/coccinelle/lilac.yaml
@@ -1,0 +1,5 @@
+maintainers:
+  - github: heavysink
+    email: winstonwu91@gmail.com
+
+managed: false

--- a/archlinuxcn/freecad/lilac.yaml
+++ b/archlinuxcn/freecad/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/gottet/lilac.yaml
+++ b/archlinuxcn/gottet/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/gradio/lilac.yaml
+++ b/archlinuxcn/gradio/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/hplip-plugin/lilac.yaml
+++ b/archlinuxcn/hplip-plugin/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/ispin/lilac.yaml
+++ b/archlinuxcn/ispin/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/lib32-gdbm/lilac.yaml
+++ b/archlinuxcn/lib32-gdbm/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: felixonmars
+
+managed: false

--- a/archlinuxcn/lib32-tk/lilac.yaml
+++ b/archlinuxcn/lib32-tk/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: felixonmars
+
+managed: false

--- a/archlinuxcn/libgit2-julia/lilac.yaml
+++ b/archlinuxcn/libgit2-julia/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/llvm-julia/lilac.yaml
+++ b/archlinuxcn/llvm-julia/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/llvm-svn/lilac.yaml
+++ b/archlinuxcn/llvm-svn/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/lumina-desktop/lilac.yaml
+++ b/archlinuxcn/lumina-desktop/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/nodejs-tiddlywiki/lilac.yaml
+++ b/archlinuxcn/nodejs-tiddlywiki/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/numix-circle-icon-theme-git/lilac.yaml
+++ b/archlinuxcn/numix-circle-icon-theme-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/numix-icon-theme-git/lilac.yaml
+++ b/archlinuxcn/numix-icon-theme-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/openvdb3/lilac.yaml
+++ b/archlinuxcn/openvdb3/lilac.yaml
@@ -1,0 +1,5 @@
+maintainers:
+  - github: heavysink
+    email: winstonwu91@gmail.com
+
+managed: false

--- a/archlinuxcn/spin/lilac.yaml
+++ b/archlinuxcn/spin/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: yuyichao
+
+managed: false

--- a/archlinuxcn/stapler-git/lilac.yaml
+++ b/archlinuxcn/stapler-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/supertux-git/lilac.yaml
+++ b/archlinuxcn/supertux-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/uksmtools/lilac.yaml
+++ b/archlinuxcn/uksmtools/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: felixonmars
+
+managed: false

--- a/archlinuxcn/xfce4-mpc-plugin-update/lilac.yaml
+++ b/archlinuxcn/xfce4-mpc-plugin-update/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/xrdp/lilac.yaml
+++ b/archlinuxcn/xrdp/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false

--- a/archlinuxcn/youtube-dl-git/lilac.yaml
+++ b/archlinuxcn/youtube-dl-git/lilac.yaml
@@ -1,0 +1,4 @@
+maintainers:
+  - github: colinkeenan
+
+managed: false


### PR DESCRIPTION
Maintainers are determined by last packagers and git commits.

Closes https://github.com/archlinuxcn/repo/issues/1325
See also: https://github.com/archlinuxcn/repo/issues/1351

Those files is created manually. Please check whether indicated maintainers in `lilac.yaml` are correct or not, thanks! @colinkeenan @felixonmars @heavysink @yuyichao

UPDATE 2019/11/15
d9f461855604c6821091e50a41388ab2dee1ae33 - I consider it a confirmation of llvm-julia maintenance.
344103f3f4253c7c7ed175c0ae7f8713596a7429 - confirmation of youtube-dl-git maintenance. See also https://github.com/archlinuxcn/repo/pull/1383.