### PR TITLE
try to resolve mycli/litecli depends issue

### DIFF
--- a/archlinuxcn/litecli/lilac.py
+++ b/archlinuxcn/litecli/lilac.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from lilaclib import *
+
+build_prefix = "extra-x86_64"
+
+def pre_build():
+  aur_pre_build()
+  for line in edit_file("PKGBUILD"):
+    if "'python-sqlparse'" in line:
+      print("'python-sqlparse-cli_helpers'")
+    else:
+      print(line)
+
+def post_build():
+  aur_post_build()
+
+
+if __name__ == "__main__":
+  single_main(build_prefix)

--- a/archlinuxcn/litecli/lilac.yaml
+++ b/archlinuxcn/litecli/lilac.yaml
@@ -5,10 +5,8 @@ build_prefix: extra-x86_64
 
 repo_depends:
   - python-cli_helpers
+  - python-sqlparse-cli_helpers
 
 update_on:
   - aur: litecli
   - alias: python
-
-pre_build: aur_pre_build
-post_build: aur_post_build

--- a/archlinuxcn/mycli/lilac.py
+++ b/archlinuxcn/mycli/lilac.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from lilaclib import *
+
+build_prefix = "extra-x86_64"
+
+def pre_build():
+  aur_pre_build()
+  for line in edit_file("PKGBUILD"):
+    if "'python-sqlparse'" in line:
+      print("'python-sqlparse-cli_helpers'")
+    else:
+      print(line)
+
+def post_build():
+  aur_post_build()
+
+
+if __name__ == "__main__":
+  single_main(build_prefix)

--- a/archlinuxcn/mycli/lilac.yaml
+++ b/archlinuxcn/mycli/lilac.yaml
@@ -3,13 +3,10 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
-
-post_build: aur_post_build
-
 update_on:
   - aur: mycli
 
 repo_depends:
   - python-pymysql
   - python-cli_helpers
+  - python-sqlparse-cli_helpers

--- a/archlinuxcn/python-sqlparse-cli_helpers/PKGBUILD
+++ b/archlinuxcn/python-sqlparse-cli_helpers/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Andrej Radović <r.andrej@gmail.com>
+pkgname=python-sqlparse-cli_helpers
+_name='sqlparse'
+pkgver=0.2.4
+pkgrel=1
+pkgdesc="Non-validating SQL parser for Python; version compatible with litecli, mycli, ..."
+url="https://github.com/andialbrecht/sqlparse"
+provides=('python-sqlparse')
+conflicts=('python-sqlparse')
+depends=('python')
+makedepends=('python-setuptools')
+license=('BSD')
+arch=('any')
+source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
+sha256sums=('ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec')
+
+build() {
+	cd "$srcdir/$_name-$pkgver"
+	python setup.py build
+}
+
+package() {
+	cd "$srcdir/$_name-$pkgver"
+	python setup.py install --root="$pkgdir" --optimize=1
+}

--- a/archlinuxcn/python-sqlparse-cli_helpers/lilac.yaml
+++ b/archlinuxcn/python-sqlparse-cli_helpers/lilac.yaml
@@ -1,0 +1,9 @@
+maintainers:
+- github: masakichi
+
+update_on:
+- aur: python-sqlparse-cli_helpers
+- alias: python
+
+pre_build: aur_pre_build
+post_build: aur_post_build


### PR DESCRIPTION
#1378 #1398 

加了一个 python-sqlparse-cli_helpers 包到 repo 里，然后 mycli/litecli 的 python-sqlparse 依赖改成 python-sqlparse-cli_helpers 应该可以解决。

然后等 pypi 上游 setup.py 里的依赖能跟上 Arch 源里的版本再改回来就行了应该。