### PR TITLE
Version bumping for hath.

### DIFF
--- a/archlinuxcn/hath/PKGBUILD
+++ b/archlinuxcn/hath/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: jtmb <packaging at technologicalwizardry dot com>
 pkgname=hath
-pkgver=1.4.2
+pkgver=1.6.0
 pkgrel=1
 pkgdesc="SETI@Home meets BitTorrent, for E-Hentai.org and E-Hentai Galleries."
 arch=(any)

--- a/archlinuxcn/hath/PKGBUILD
+++ b/archlinuxcn/hath/PKGBUILD
@@ -8,11 +8,11 @@ url="https://ehwiki.org/wiki/Hentai@Home"
 license=('GPL')
 depends=(java-runtime)
 makedepends=(java-environment)
-source=("https://repo.e-hentai.org/hath/HentaiAtHome_1.4.2_src.zip"
+source=("https://repo.e-hentai.org/hath/HentaiAtHome_1.6.0_src.zip"
         "hath.sh"
        	"hath.service")
 install="${pkgname}.install"
-sha256sums=('5711c5dac5481ba75d24751720035b85a02edbce66f1d155824bf4060455e38a'
+sha256sums=('3c807dadb3303a407101c428c65a68f55b3463fc3da29133ffe43b73591eaab8'
 			'737d8b70150f9e897c3f7413669562f1f92e0df6539403f1936d6463e832c841'
 			'8afd6ff66bfa986c7787e39aaad5d35a5ce1e2b722edb95bc86f76965d8d9fd0')
 


### PR DESCRIPTION
Bump the version of Hath from 1.4.2 to 1.6.0