### PR TITLE
gnome-shell-extension-volume-mixer-git: Fix pkgver()

### DIFF
--- a/archlinuxcn/gnome-shell-extension-volume-mixer-git/PKGBUILD
+++ b/archlinuxcn/gnome-shell-extension-volume-mixer-git/PKGBUILD
@@ -23,8 +23,6 @@ conflicts+=("$_gitname")
 pkgver() {
   cd ${_gitname:-$pkgname}
   git describe --long --tags 2>/dev/null | sed 's/[^[:digit:]]*\(.\+\)-\([[:digit:]]\+\)-g\([[:xdigit:]]\{7\}\)/\1.r\2.g\3/;t;q1'
-  [ ${PIPESTATUS[0]} -ne 0 ] && \
-printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 package() {
   for function in $(declare -F | grep -Po 'package_[[:digit:]]+[[:alpha:]_]*$')


### PR DESCRIPTION
`updpkgsums` is unnecessary because of [this](https://github.com/archlinuxcn/repo/blob/master/archlinuxcn/gnome-shell-extension-volume-mixer-git/PKGBUILD#L16-L20).