### PR TITLE
ferdi-git: switch to electron v8

### DIFF
--- a/archlinuxcn/ferdi-git/PKGBUILD
+++ b/archlinuxcn/ferdi-git/PKGBUILD
@@ -5,13 +5,13 @@
 # Contributor: Pieter Goetschalckx <3.14.e.ter <at> gmail <dot> com>
 _pkgname='ferdi'
 pkgname="$_pkgname-git"
-pkgver=5.4.4.beta.2.r10.ge043795a
+pkgver=5.4.4.beta.2.r13.gaf64cbf2
 pkgrel=1
 pkgdesc='A messaging browser that allows you to combine your favorite messaging services into one application - git version'
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://get$_pkgname.com"
 license=('Apache')
-depends=('electron6' 'libxkbfile')
+depends=('electron' 'libxkbfile')
 makedepends=('git' 'npm' 'python')
 provides=("$_pkgname")
 conflicts=("$_pkgname")
@@ -27,7 +27,7 @@ sha256sums=('SKIP'
             'SKIP'
             'SKIP'
             '5013233fc508f16b6782efa72da2ac242996f8555b3135aa0d2d98029c2bbc53'
-            '215f0e3587b6b5dca97bdd2ab238e39b763b57df61a44fd6b1baef6e23745caa'
+            '3a21a67cc821892f9ae1b53b9108ec1859aa42b301fa6523c6c7accf6bc2a6c5'
             '91cc72f00db20e1bded69d08578e6ae9fdc89a4582ee8f6d29697b0233d7d095')
 
 _sourcedirectory="$pkgname"
@@ -47,7 +47,7 @@ prepare() {
 	git submodule update --init --recursive
 
 	# Set system Electron version for ABI compatibility
-	sed -E -i 's|("electron": ").*"|\1'"$(cat '/usr/lib/electron6/version')"'"|' 'package.json'
+	sed -E -i 's|("electron": ").*"|\1'"$(cat '/usr/lib/electron/version')"'"|' 'package.json'
 
 	# Prevent Ferdi from being launched in dev mode
 	sed -i "s|import isDevMode from 'electron-is-dev'|const isDevMode = false|g" 'src/index.js' 'src/config.js'
@@ -90,7 +90,7 @@ build() {
 	export npm_config_cache="$srcdir/$pkgname-npm-cache"
 
 	npx gulp build
-	npx electron-builder --linux dir "--$_electronbuilderarch" -c.electronDist='/usr/lib/electron6' -c.electronVersion="$(cat '/usr/lib/electron6/version')"
+	npx electron-builder --linux dir "--$_electronbuilderarch" -c.electronDist='/usr/lib/electron' -c.electronVersion="$(cat '/usr/lib/electron/version')"
 }
 
 package() {

--- a/archlinuxcn/ferdi-git/ferdi.sh
+++ b/archlinuxcn/ferdi-git/ferdi.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec electron6 '/usr/lib/ferdi/app.asar' "$@"
+exec electron '/usr/lib/ferdi/app.asar' "$@"

--- a/archlinuxcn/ferdi-git/lilac.yaml
+++ b/archlinuxcn/ferdi-git/lilac.yaml
@@ -8,6 +8,6 @@ post_build: git_pkgbuild_commit
 
 update_on:
   - github: getferdi/ferdi
-  - archpkg: electron6
+  - archpkg: electron
     from_pattern: '^(\d+\.\d+)\..*'
     to_pattern: '\1'


### PR DESCRIPTION
Upstream ferdi is using electron v8 since [5.4.4-beta.2](https://github.com/getferdi/ferdi/releases/tag/v5.4.4-beta.2).

This package is still using electron v6. This PR changes that.