### PR TITLE
qv2ray-dev-git: updating dependencies

### DIFF
--- a/archlinuxcn/qv2ray-dev-git/PKGBUILD
+++ b/archlinuxcn/qv2ray-dev-git/PKGBUILD
@@ -2,13 +2,13 @@
 # Contributer: ArielAxionL <i at axionl dot me>
 # Contributor: DuckSoft <realducksoft@gmail.com>
 pkgname=qv2ray-dev-git
-pkgver=2.3.2.4981+grpc
+pkgver=2.3.2.4993+grpc
 pkgrel=1
 pkgdesc="Cross-platform V2ray Client written in Qt (Development Release)"
 arch=('x86_64')
 url='https://github.com/Qv2ray/Qv2ray'
 license=('GPL3')
-depends=('hicolor-icon-theme' 'qt5-base>5.11.0' 'grpc>=1.27.0')
+depends=('hicolor-icon-theme' 'qt5-base>5.11.0' 'grpc>=1.27.0' 'zxing-cpp')
 optdepends=('v2ray: use system v2ray core.')
 makedepends=('git' 'make' 'qt5-tools' 'which' 'gcc' 'qt5-declarative'
              'grpc-cli>=1.27.0' 'cmake' 'ninja')
@@ -20,14 +20,10 @@ source=(
     'QNodeEditor::git+https://github.com/Qv2ray/QNodeEditor'
     'SingleApplication::git+https://github.com/itay-grudev/SingleApplication'
     'x2struct::git+https://github.com/xyz347/x2struct'
-    'qzxing::git+https://github.com/ftylitak/qzxing'
-    'qhttpserver::git+https://github.com/nikhilm/qhttpserver'
     'cpp-httplib::git+https://github.com/yhirose/cpp-httplib'
 )
 
 sha512sums=('SKIP'
-            'SKIP'
-            'SKIP'
             'SKIP'
             'SKIP'
             'SKIP'
@@ -40,12 +36,13 @@ pkgver() {
 prepare() {
     cd "${srcdir}/Qv2ray"
     git submodule init
-    submodules=('QNodeEditor' 'SingleApplication' 'x2struct' 'qhttpserver' 'qzxing' 'cpp-httplib')
+    submodules=('QNodeEditor' 'SingleApplication' 'x2struct' 'cpp-httplib')
     for module in ${submodules[@]}; do
         git config submodule."3rdparty/$module".url "${srcdir}/$module"
     done
     
     git config submodule."libs/libqvb".active false
+    git config submodule."3rdparty/zxing-cpp".active false
     git submodule update
 }
 
@@ -57,6 +54,7 @@ build() {
     mkdir -p build && cd build
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=${pkgdir}/usr \
+        -DQV2RAY_ZXING_PROVIDER="package" \
         -DQV2RAY_TRANSLATION_PATH="/usr/share/qv2ray/lang" \
         -DQV2RAY_DEFAULT_VASSETS_PATH="/usr/lib/v2ray" \
         -DQV2RAY_DEFAULT_VCORE_PATH="/usr/lib/v2ray/v2ray" \


### PR DESCRIPTION
upstream changes:
 - `qzxing` => `zxing-cpp` (use existing package in `extra` repo)
 - deleted dependency of `qhttpserver`
