### PR TITLE
Better TimeoutStartSec=infinity instead of 0.

### DIFF
--- a/archlinuxcn/k3s-bin/k3s.service
+++ b/archlinuxcn/k3s-bin/k3s.service
@@ -15,7 +15,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
-TimeoutStartSec=0
+TimeoutStartSec=infinity
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
See https://www.freedesktop.org/software/systemd/man/systemd.service.html