### PR TITLE
Test for invalid repo_depends items (closes #1414)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - "3.6"
+    - "3.8"
 
 # Use container-based infrastructure for quicker build start-up
 sudo: false

--- a/archlinuxcn/armadillo/lilac.yaml
+++ b/archlinuxcn/armadillo/lilac.yaml
@@ -11,6 +11,3 @@ post_build: aur_post_build
 
 update_on:
   - aur: armadillo
-
-repo_depends:
-  - superlu

--- a/archlinuxcn/fs-uae-arcade-devel/lilac.yaml
+++ b/archlinuxcn/fs-uae-arcade-devel/lilac.yaml
@@ -8,7 +8,6 @@ build_prefix: extra-x86_64
 
 repo_depends:
   - fs-uae-devel
-  - python-lhafile
 
 pre_build: aur_pre_build
 

--- a/pre-commit
+++ b/pre-commit
@@ -372,6 +372,27 @@ class RepoTreeTest(TestCase):
                     check_var_srcinfo('replaces', package, PACKAGES, line)
                     check_var_srcinfo('groups', package, GROUPS, line)
 
+    def test_repo_depends_valid(self):
+        pkgs = list(list_packages())
+        for package in pkgs:
+            with self.subTest(package=package):
+                self.assertFalse(
+                    lilac_py_has_field(package, 'repo_depends', self),
+                    msg=('package "\033[1;31m{0}\033[m" has repo_depends '
+                         'in lilac.py').format(package))
+                lilac_yaml_path = os.path.join(pkgpath(package), 'lilac.yaml')
+                with git_open(lilac_yaml_path) as lilac_yaml_file:
+                    lilac_yaml = yaml.load(lilac_yaml_file.read(), Loader=yaml.SafeLoader)
+                    for dep in lilac_yaml.get('repo_depends', []):
+                        if isinstance(dep, dict):
+                            dep_package = list(dep.keys())[0]
+                        else:
+                            dep_package = dep
+                        self.assertTrue(
+                            dep_package in pkgs,
+                            msg=('package "\033[1;31m{0}\033[m" depends on '
+                                 '"\033[1;31m{1}\033[m", which does not exist '
+                                 'or is unmanaged').format(package, dep_package))
 
 
 def run_test(testcase, msg):

--- a/pre-commit
+++ b/pre-commit
@@ -385,6 +385,10 @@ class RepoTreeTest(TestCase):
                     lilac_yaml = yaml.load(lilac_yaml_file.read(), Loader=yaml.SafeLoader)
                     for dep in lilac_yaml.get('repo_depends', []):
                         if isinstance(dep, dict):
+                            # When `dep` is a dict, this repo_depends entry
+                            # has the form `pkgbase: pkgname`. Here I assume
+                            # split packages are successfully packaged. so only
+                            # the pkgbase needs to be checked.
                             dep_package = list(dep.keys())[0]
                         else:
                             dep_package = dep


### PR DESCRIPTION
Marked as draft as this depends on https://github.com/archlinuxcn/lilac/pull/144. Will update after that pull request is merged or another approach is proposed.

See https://travis-ci.org/github/yan12125/repo/builds/673671061 for an example failing test.