### PR TITLE
qv2ray: removing unused dependency

### DIFF
--- a/archlinuxcn/qv2ray/PKGBUILD
+++ b/archlinuxcn/qv2ray/PKGBUILD
@@ -20,11 +20,9 @@ source=(
     'QNodeEditor::git+https://github.com/Qv2ray/QNodeEditor'
     'SingleApplication::git+https://github.com/itay-grudev/SingleApplication'
     'x2struct::git+https://github.com/xyz347/x2struct'
-    'cpp-httplib::git+https://github.com/yhirose/cpp-httplib'
 )
 
 sha512sums=('SKIP'
-            'SKIP'
             'SKIP'
             'SKIP'
             'SKIP')


### PR DESCRIPTION
Qv2ray v2.5.0 introduced plugin feature and removed its built-in PAC server.
The aforementioned dependency is no longer needed.