### PR TITLE
chromium-vaapi: Should rebuild on "re2" update

### DIFF
--- a/archlinuxcn/chromium-vaapi/lilac.yaml
+++ b/archlinuxcn/chromium-vaapi/lilac.yaml
@@ -10,4 +10,6 @@ time_limit_hours: 4
 update_on:
   - aur: chromium-vaapi
   - alias: icu
-
+  - archpkg: re2
+    provided: libre2.so.6
+    strip-release: true


### PR DESCRIPTION
Recent `re2` update (`1:20200401-1` -> `1:20200501-1`) breaks `chromium-vaapi`:

```
/usr/lib/chromium/chromium: error while loading shared libraries: libre2.so.6: cannot open shared object file: No such file or directory
```

I don't really know if it's how lilac works, but maybe we can rebuild `chromium-vaapi` on `re2` upgrades.