### PR TITLE
Migrate repo_depends in lilac.py to lilac.yaml

### DIFF
--- a/archlinuxcn/bomi-git/lilac.py
+++ b/archlinuxcn/bomi-git/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}, {'github':'demokritos/bomi'}, {'archpkg': 'libdvdread'}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['libchardet']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/breeze-plymouth/lilac.py
+++ b/archlinuxcn/breeze-plymouth/lilac.py
@@ -7,8 +7,6 @@
 
 from lilaclib import *
 
-repo_depends = ['plymouth-git']
-
 #build_prefix = 'extra-x86_64'
 #pre_build = aur_pre_build
 #post_build = aur_post_build

--- a/archlinuxcn/breeze-plymouth/lilac.yaml
+++ b/archlinuxcn/breeze-plymouth/lilac.yaml
@@ -11,3 +11,5 @@ post_build: aur_post_build
 
 update_on:
   - aur: breeze-plymouth
+repo_depends:
+  - plymouth-git

--- a/archlinuxcn/bypy-git/lilac.py
+++ b/archlinuxcn/bypy-git/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}, {'github':'houtianze/bypy'}, {'alias':'python'}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['python-multiprocess']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/cndrvcups-lb/lilac.py
+++ b/archlinuxcn/cndrvcups-lb/lilac.py
@@ -7,8 +7,6 @@
 
 from lilaclib import *
 
-repo_depends = ['cndrvcups-common-lb']
-
 #build_prefix = 'multilib'
 #pre_build = aur_pre_build
 #post_build = aur_post_build

--- a/archlinuxcn/cndrvcups-lb/lilac.yaml
+++ b/archlinuxcn/cndrvcups-lb/lilac.yaml
@@ -11,3 +11,5 @@ post_build: aur_post_build
 
 update_on:
   - aur: cndrvcups-lb
+repo_depends:
+  - cndrvcups-common-lb

--- a/archlinuxcn/libbonobo/lilac.py
+++ b/archlinuxcn/libbonobo/lilac.py
@@ -11,7 +11,5 @@ from lilaclib import *
 #pre_build = aur_pre_build
 #post_build = aur_post_build
 
-repo_depends = ["orbit2"]
-
 #if __name__ == '__main__':
 #      single_main(build_prefix)

--- a/archlinuxcn/libbonobo/lilac.yaml
+++ b/archlinuxcn/libbonobo/lilac.yaml
@@ -11,3 +11,5 @@ post_build: aur_post_build
 
 update_on:
   - aur: libbonobo
+repo_depends:
+  - orbit2

--- a/archlinuxcn/minecraft/lilac.py
+++ b/archlinuxcn/minecraft/lilac.py
@@ -3,8 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['gconf']
-
 def pre_build():
     aur_pre_build()
     run_cmd(['sh', '-c', 'rm *.deb'])

--- a/archlinuxcn/ocserv/lilac.py
+++ b/archlinuxcn/ocserv/lilac.py
@@ -9,8 +9,6 @@ from lilaclib import *
 
 #build_prefix = 'extra-x86_64'
 
-repo_depends=['libpcl', 'freeradius-client']
-
 def pre_build():
     update_pkgver_and_pkgrel(_G.newver)
 

--- a/archlinuxcn/ocserv/lilac.yaml
+++ b/archlinuxcn/ocserv/lilac.yaml
@@ -8,3 +8,6 @@ build_prefix: extra-x86_64
 update_on:
   - github: openconnect/ocserv
     use_max_tag: true
+repo_depends:
+  - libpcl
+  - freeradius-client

--- a/archlinuxcn/p7zip-natspec/lilac.py
+++ b/archlinuxcn/p7zip-natspec/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['libnatspec']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/p7zip-natspec/lilac.yaml
+++ b/archlinuxcn/p7zip-natspec/lilac.yaml
@@ -5,3 +5,5 @@ update_on:
   - aur: p7zip-natspec
 pre_build: aur_pre_build
 post_build: aur_post_build
+repo_depends:
+  - libnatspec

--- a/archlinuxcn/perl-cpanel-json-xs/lilac.py
+++ b/archlinuxcn/perl-cpanel-json-xs/lilac.py
@@ -1,7 +1,5 @@
 from lilaclib import *
 
 build_prefix = "extra-x86_64"
-repo_depends = []
-
 if __name__ == "__main__":
     single_main('extra-x86_64')

--- a/archlinuxcn/perl-goo-canvas/lilac.py
+++ b/archlinuxcn/perl-goo-canvas/lilac.py
@@ -11,7 +11,5 @@ from lilaclib import *
 #pre_build = aur_pre_build
 #post_build = aur_post_build
 
-repo_depends = ["goocanvas1"]
-
 #if __name__ == '__main__':
 #      single_main(build_prefix)

--- a/archlinuxcn/perl-goo-canvas/lilac.yaml
+++ b/archlinuxcn/perl-goo-canvas/lilac.yaml
@@ -11,3 +11,5 @@ post_build: aur_post_build
 
 update_on:
   - aur: perl-goo-canvas
+repo_depends:
+  - goocanvas1

--- a/archlinuxcn/perl-json-maybexs/lilac.py
+++ b/archlinuxcn/perl-json-maybexs/lilac.py
@@ -1,6 +1,4 @@
 from lilaclib import *
 
-repo_depends = ["perl-cpanel-json-xs"]
-
 if __name__ == "__main__":
     single_main("extra-x86_64")

--- a/archlinuxcn/perl-json-maybexs/lilac.yaml
+++ b/archlinuxcn/perl-json-maybexs/lilac.yaml
@@ -7,3 +7,5 @@ post_build: aur_post_build
 
 update_on:
   - aur: perl-json-maybexs
+repo_depends:
+  - perl-cpanel-json-xs

--- a/archlinuxcn/pm2ml/lilac.py
+++ b/archlinuxcn/pm2ml/lilac.py
@@ -8,8 +8,6 @@
 from lilaclib import *
 
 #build_prefix = 'archlinuxcn-x86_64'
-repo_depends = ['python3-xcgf', 'python3-xcpf']
-
 #pre_build = aur_pre_build
 
 #post_build = aur_post_build

--- a/archlinuxcn/pm2ml/lilac.yaml
+++ b/archlinuxcn/pm2ml/lilac.yaml
@@ -12,3 +12,6 @@ post_build: aur_post_build
 update_on:
   - aur: pm2ml
   - alias: python
+repo_depends:
+  - python3-xcgf
+  - python3-xcpf

--- a/archlinuxcn/powerpill/lilac.py
+++ b/archlinuxcn/powerpill/lilac.py
@@ -8,8 +8,6 @@
 from lilaclib import *
 
 #build_prefix = 'extra-x86_64'
-repo_depends = ['python3-memoizedb', 'python3-xcgf', 'python3-xcpf', 'pm2ml']
-
 def pre_build():
   # obtain base PKGBUILD, e.g.
   aur_pre_build()

--- a/archlinuxcn/powerpill/lilac.yaml
+++ b/archlinuxcn/powerpill/lilac.yaml
@@ -10,3 +10,8 @@ post_build: aur_post_build
 update_on:
   - aur: powerpill
   - alias: python
+repo_depends:
+  - python3-memoizedb
+  - python3-xcgf
+  - python3-xcpf
+  - pm2ml

--- a/archlinuxcn/python-multiprocess/lilac.py
+++ b/archlinuxcn/python-multiprocess/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur': None}, {'alias':'python'}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['python-dill', ('python-dill', 'python2-dill')]
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/python3-aur/lilac.py
+++ b/archlinuxcn/python3-aur/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}, {'alias': 'python'}, {'alias':'python'}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['python3-xcpf', 'python3-xcgf']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/python3-xcgf/lilac.py
+++ b/archlinuxcn/python3-xcgf/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}, {'alias':'python'}]
 build_prefix = 'extra-x86_64'
-repo_depends= ['python3-memoizedb']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/python3-xcgf/lilac.yaml
+++ b/archlinuxcn/python3-xcgf/lilac.yaml
@@ -6,3 +6,5 @@ update_on:
   - alias: python
 pre_build: aur_pre_build
 post_build: aur_post_build
+repo_depends:
+  - python3-memoizedb

--- a/archlinuxcn/python3-xcpf/lilac.py
+++ b/archlinuxcn/python3-xcpf/lilac.py
@@ -6,7 +6,6 @@
 #
 
 from lilaclib import *
-repo_depends=['python3-memoizedb', 'python3-xcgf']
 #build_prefix = 'extra-x86_64'
 #pre_build = aur_pre_build
 #post_build = aur_post_build

--- a/archlinuxcn/python3-xcpf/lilac.yaml
+++ b/archlinuxcn/python3-xcpf/lilac.yaml
@@ -12,3 +12,6 @@ post_build: aur_post_build
 update_on:
   - aur: python3-xcpf
   - alias: python
+repo_depends:
+  - python3-memoizedb
+  - python3-xcgf

--- a/archlinuxcn/ssf2fcitx-git/lilac.py
+++ b/archlinuxcn/ssf2fcitx-git/lilac.py
@@ -1,6 +1,4 @@
 from lilaclib import *
 
-repo_depends = []
-
 if __name__ == "__main__":
     single_main('extra-x86_64')

--- a/archlinuxcn/unzip-natspec/lilac.py
+++ b/archlinuxcn/unzip-natspec/lilac.py
@@ -3,7 +3,6 @@ from lilaclib import *
 
 update_on = [{'aur':None}]
 build_prefix = 'extra-x86_64'
-repo_depends = ['libnatspec']
 pre_build = aur_pre_build
 post_build = aur_post_build
 

--- a/archlinuxcn/unzip-natspec/lilac.yaml
+++ b/archlinuxcn/unzip-natspec/lilac.yaml
@@ -5,3 +5,5 @@ update_on:
   - aur: unzip-natspec
 pre_build: aur_pre_build
 post_build: aur_post_build
+repo_depends:
+  - libnatspec


### PR DESCRIPTION
Converted with the following command
```
for pkgbase in $(rg -lg 'lilac.py' repo_depends | sed 's#/lilac.py##') ; do ; python ../../aur/scripts/migrate.py $pkgbase ; done
```
Using https://gitlab.com/yan12125/aur/-/blob/9b6d81ba9ff49aa842943bf5326ce9b4dc5060e2/scripts/migrate.py

For some packages, repo_depends in lilac.py already has an equivalent
value in lilac.yaml, so lilac.yaml is not updated.

Ref: https://github.com/archlinuxcn/repo/issues/990