### PR TITLE
Update wine-wechat.desktop

### DIFF
--- a/archlinuxcn/wine-wechat/wine-wechat.desktop
+++ b/archlinuxcn/wine-wechat/wine-wechat.desktop
@@ -10,3 +10,4 @@ StartupNotify=true
 Terminal=0
 Type=Application
 Categories=Network;InstantMessaging;
+Keywords=wx;wechat;weixin


### PR DESCRIPTION
方便搜索，原来的 GNOME shell 必须打中文微信或者先输wine然后才有，不方便。
主要是解决locale是中文的情况，如果是英文的话可能输wechat可以出来吧