### PR TITLE
qv2ray: rebuild due to protobuf soversion bump

### DIFF
--- a/archlinuxcn/qv2ray/PKGBUILD
+++ b/archlinuxcn/qv2ray/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Leroy.H.Y <me at lhy0403 dot top>
 pkgname=qv2ray
 pkgver=2.5.0
-pkgrel=3
+pkgrel=3.1
 pkgdesc="Cross-platform V2ray Client written in Qt (Stable Release)"
 arch=('x86_64')
 url='https://github.com/Qv2ray/Qv2ray'

--- a/archlinuxcn/qv2ray/lilac.yaml
+++ b/archlinuxcn/qv2ray/lilac.yaml
@@ -6,3 +6,4 @@ build_prefix: extra-x86_64
 update_on:
   - github: Qv2ray/Qv2ray
     use_latest_release: true
+  - alias: protobuf


### PR DESCRIPTION
upstream `protobuf` bumped soversion recently.
a rebuilld is needed.