### PR TITLE
trojan-go-git: enable PIE

### DIFF
--- a/archlinuxcn/trojan-go-git/PKGBUILD
+++ b/archlinuxcn/trojan-go-git/PKGBUILD
@@ -23,10 +23,14 @@ build() {
     
     # NOTE: uncomment the following line if you are in mainland china
     # export GOPROXY="https://goproxy.cn,direct"
-    export CGO_ENABLED=0
+    export CGO_ENABLED=1
     export GO111MODULE=on
 
-    go build -v -tags "full" -ldflags="-s -w" -o trojan-go .
+    go build -v \
+        -buildmode=pie -trimpath -mod=readonly -modcacherw \
+        -tags "full" \
+        -ldflags="-s -w -extldflags=-Wl,-z,now,-z,relro" \
+        -o trojan-go .
 }
 
 package() {


### PR DESCRIPTION
according to https://wiki.archlinux.org/index.php/Go_package_guidelines

```
❰ducksoft❙~❱✔≻ file /usr/lib/trojan-go/trojan-go
/usr/lib/trojan-go/trojan-go: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=a3beead5cfa934860e1acf128f29ba06003ca6a5, for GNU/Linux 3.2.0, stripped
```