### PR TITLE
misc: fix crates.io url

### DIFF
--- a/archlinuxcn/dutree/PKGBUILD
+++ b/archlinuxcn/dutree/PKGBUILD
@@ -10,7 +10,7 @@ license=('GPL-3.0')
 makedepends=('rust' 'cargo')
 depends=()
 provides=("$_pkgname")
-source=($_pkgname.tar.gz::"https://crates.io//api/v1/crates/$_pkgname/$pkgver/download")
+source=($_pkgname.tar.gz::"https://crates.io/api/v1/crates/$_pkgname/$pkgver/download")
 sha256sums=('6821159741d437f12e636bb86975255079f9188766ab167f61fa674329579bfe')
 
 build() {

--- a/archlinuxcn/mcfly/PKGBUILD
+++ b/archlinuxcn/mcfly/PKGBUILD
@@ -10,7 +10,7 @@ license=('MIT')
 makedepends=('rust' 'cargo')
 depends=()
 provides=("$_pkgname")
-source=($_pkgname.tar.gz::"https://crates.io//api/v1/crates/$_pkgname/$pkgver/download")
+source=($_pkgname.tar.gz::"https://crates.io/api/v1/crates/$_pkgname/$pkgver/download")
 sha256sums=('45492db1c582fc53acc13287242e39cc164adb1c87834117377d14c71f683d21')
 
 install=${pkgname}.install

--- a/archlinuxcn/pijul/PKGBUILD
+++ b/archlinuxcn/pijul/PKGBUILD
@@ -10,7 +10,7 @@ license=('GPL-2.0+')
 makedepends=('rust' 'cargo' 'clang')
 depends=('libsodium')
 provides=("$_pkgname")
-source=($_pkgname.tar.gz::"https://crates.io//api/v1/crates/$_pkgname/$pkgver/download")
+source=($_pkgname.tar.gz::"https://crates.io/api/v1/crates/$_pkgname/$pkgver/download")
 sha256sums=('f92a3f4063e780ca45c161ceb0f42baf34dfeddf3359ebf6c2e0442d9abb5889')
 
 build() {


### PR DESCRIPTION
The extra `/` will cause 404 when trying to download crate.

This may help to fi.x #1718.

```bash
❯ curl -I https://crates.io//api/v1/crates/mcfly/0.4.0/download
HTTP/2 404
content-type: application/json; charset=utf-8
content-length: 35
server: nginx
date: Mon, 06 Jul 2020 04:49:53 GMT
strict-transport-security: max-age=31536000
via: 1.1 vegur, 1.1 73d3ff0182f526d6384b20c342c6483b.cloudfront.net (CloudFront)
x-cache: Error from cloudfront
x-amz-cf-pop: SFO20-C1
x-amz-cf-id: N7mxgowm2IGRSgqTHLO8DNxC3_2INLYfjAf0elzMh4mtQ1DcjXwrfg==

❯ curl -I https://crates.io/api/v1/crates/mcfly/0.4.0/download
HTTP/2 302
content-length: 0
location: https://static.crates.io/crates/mcfly/mcfly-0.4.0.crate
server: nginx
date: Mon, 06 Jul 2020 04:49:57 GMT
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
content-security-policy: default-src 'self'; connect-src 'self' https://docs.rs https://static.crates.io; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://www.gstatic.com https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'
access-control-allow-origin: *
strict-transport-security: max-age=31536000
via: 1.1 vegur, 1.1 1f2a2b4522308aae8508a9096d87b334.cloudfront.net (CloudFront)
vary: Accept,Accept-Encoding,Cookie
x-cache: Miss from cloudfront
x-amz-cf-pop: SFO20-C1
x-amz-cf-id: 7OLqXw_KiB9G5ssjYZjUVagIiIYMHG23aQmvkBYXX-ZAWmR41aycUA==
```