### PR TITLE
emacs-native-comp-git: fix branch name in lilac.yaml

### DIFF
--- a/archlinuxcn/emacs-native-comp-git/lilac.yaml
+++ b/archlinuxcn/emacs-native-comp-git/lilac.yaml
@@ -11,5 +11,5 @@ post_build: aur_post_build
 
 update_on:
   - github: emacs-mirror/emacs
-    branch: native-comp
+    branch: feature/native-comp
   - aur: emacs-native-comp-git


### PR DESCRIPTION
change the branch name from 'native-comp' to 'feature/native-comp'