### PR TITLE
addpkg: ttf-cascadia-code-new

### DIFF
--- a/archlinuxcn/ttf-cascadia-code-new/lilac.yaml
+++ b/archlinuxcn/ttf-cascadia-code-new/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: Camberloid
+    email: Camber/Billy Huang <camber@poi.science>
+
+update_on:
+  - aur: ttf-cascadia-code-new
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build


### PR DESCRIPTION
**This PR will solve #1762**

Refer to #1762

> 由于官方仓库 community/ttf-cascadia-code (版本号 1910.04-2) 无非连字的字体
> 而上游自版本号1911开始提供非连字字体Cascadia Mono (Reference)
> 另外, 想着自己提个PR, 但是碍于目前并不了解 archlinuxcn/repo 的工作流
> 故提出本Issue

听说最小的AUR -> Archcn的搬运是只编写`lilac.yaml`, 故暂时没写`PKGBUILD`

这是Camber的第一次搬运, 请各位朋友帮忙进行Review. 感谢