### PR TITLE
addpkg: haskell-language-server-bin

### DIFF
--- a/archlinuxcn/haskell-language-server-bin/lilac.yaml
+++ b/archlinuxcn/haskell-language-server-bin/lilac.yaml
@@ -1,0 +1,9 @@
+maintainers:
+  - github: berberman
+
+pre_build_script: aur_pre_build(maintainers='berberman')
+
+post_build: aur_post_build
+
+update_on:
+  - aur


### PR DESCRIPTION
Haskell language server was released 5 days ago with pre-built binaries. To Be Reviewed.