### PR TITLE
fcitx5-pinyin-moegirl: Change repo name

### DIFF
--- a/archlinuxcn/fcitx5-pinyin-moegirl/PKGBUILD
+++ b/archlinuxcn/fcitx5-pinyin-moegirl/PKGBUILD
@@ -6,7 +6,7 @@ pkgver=20200730
 pkgrel=1
 pkgdesc="Fcitx 5 Pinyin Dictionary from zh.moegirl.org"
 arch=('any')
-url="https://github.com/outloudvi/fcitx5-pinyin-moegirl"
+url="https://github.com/outloudvi/mw2fcitx"
 license=('CCPL:by-nc-sa-3.0')
 source=("${url}/releases/download/${pkgver}/moegirl.dict"
         "${url}/releases/download/${pkgver}/moegirl.dict.yaml")

--- a/archlinuxcn/fcitx5-pinyin-moegirl/lilac.yaml
+++ b/archlinuxcn/fcitx5-pinyin-moegirl/lilac.yaml
@@ -7,5 +7,5 @@ build_prefix: extra-x86_64
 post_build: git_pkgbuild_commit
 
 update_on:
-  - github: outloudvi/fcitx5-pinyin-moegirl
+  - github: outloudvi/mw2fcitx
     use_latest_release: true


### PR DESCRIPTION
tl;dr, the repository path is changed to `outloudvi/mw2fcitx`. By the way:

`fcitx-pinyin-moegirl` has pivoted to a general-purposed MediaWiki-to-fcitx pip module called [`mw2fcitx`](https://pypi.org/project/mw2fcitx/). As a result:
1. The repository is renamed to `outloudvi/mw2fcitx`, which is what this PR is about.
2. The dictionary generating script is simplified to just one line of code: `mw2fcitx -c moegirl_dict.py` (the configuration file `moegirl_dict.py` is [here](https://github.com/outloudvi/mw2fcitx/blob/pkg-moegirl/utils/moegirl_dict.py))

Due to the eased process, maybe you want to generate the dictionary directly on the building machine. A normal generating process costs about over 90 minutes (considering moegirl.org.cn is in mainland China now) for a server outside mainland China, most of which is cost on requesting the API of moegirl.org.cn.