### PR TITLE
addpkg: ghcup-hs-bin

### DIFF
--- a/archlinuxcn/ghcup-hs-bin/lilac.yaml
+++ b/archlinuxcn/ghcup-hs-bin/lilac.yaml
@@ -1,0 +1,10 @@
+ maintainers:
+  - github: berberman
+
+post_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: ghcup-hs-bin


### PR DESCRIPTION
an alternative to bootstrap static ghc