### PR TITLE
addpkg: cherrytree

### DIFF
--- a/archlinuxcn/cherrytree/PKGBUILD
+++ b/archlinuxcn/cherrytree/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Morgenstern <charles [at] charlesbwise [dot] com>
+
+pkgname=cherrytree
+pkgver=0.99.22
+pkgrel=1
+pkgdesc="Hierarchical note-taking application"
+arch=('x86_64')
+url="https://www.giuspen.com/cherrytree/"
+license=('GPL3')
+depends=('gspell'
+	 'gtksourceviewmm'
+	 'libxml++2.6'
+	 'uchardet')
+makedepends=('cmake'
+	     'python-lxml')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/giuspen/cherrytree/archive/${pkgver}.tar.gz")
+sha256sums=('7301a34010253eb7ac654ecda9f3469734a86c5370051dea1899c5fa472d9394')
+
+build() {
+  cmake \
+	-B "${pkgname}-${pkgver}/build" \
+	-S "${pkgname}-${pkgver}" \
+	-DBUILD_TESTING:BOOL=OFF \
+	-Wno-dev
+  make -C "${pkgname}-${pkgver}/build"
+}
+
+package() {
+  make -C "${pkgname}-${pkgver}/build" DESTDIR="${pkgdir}" install
+}

--- a/archlinuxcn/cherrytree/lilac.yaml
+++ b/archlinuxcn/cherrytree/lilac.yaml
@@ -1,0 +1,13 @@
+maintainers:
+  - github: YuutaW
+    email: trumeetc@gmail.com
+
+build_prefix: extra-x86_64
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: cherrytree


### PR DESCRIPTION
CherryTree is an awesome app that enables users to take notes and manage them. It also supports rich formatting. This AUR package contains a complete build instructions for CherryTree, and I had successfully made it on my machine. It would be better for users to have a prebuilt package in the Archlinux CN repo. 