### PR TITLE
addpkg: lilac-git

### DIFF
--- a/archlinuxcn/lilac-git/PKGBUILD
+++ b/archlinuxcn/lilac-git/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Chih-Hsuan Yen <yan12125@gmail.com>
+
+_pkgname=lilac
+pkgname=$_pkgname-git
+pkgver=r795.fdae52a
+pkgrel=1
+pkgdesc='The build bot for archlinuxcn'
+arch=(any)
+url='https://github.com/archlinuxcn/lilac'
+license=(GPL3)
+depends=(python git devtools nvchecker gnupg pid_children fakeroot
+         python-requests python-lxml python-yaml python-toml pyalpm
+         python-structlog python-prctl)
+makedepends=(python-setuptools-scm)
+optdepends=(
+  'smtp-forwarder: for sending error reports'
+)
+checkdepends=(python-pytest)
+provides=("$_pkgname=$pkgver")
+conflicts=("$_pkgname")
+source=('git+https://github.com/archlinuxcn/lilac.git')
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $_pkgname
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd $_pkgname
+  python setup.py build
+}
+
+check() {
+  cd $_pkgname
+  pytest
+}
+
+package() {
+  cd $_pkgname
+  python setup.py install --root="$pkgdir" --optimize=1 --skip-build
+  install -Dm644 config.toml.sample -t "$pkgdir"/usr/share/doc/lilac
+}

--- a/archlinuxcn/lilac-git/lilac.yaml
+++ b/archlinuxcn/lilac-git/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: yan12125
+
+build_prefix: extra-x86_64
+
+repo_depends:
+  - pid_children-git
+
+pre_build: vcs_update
+
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    github: archlinuxcn/lilac
+  - alias: python


### PR DESCRIPTION
Depends on ongoing upstream PRs: https://github.com/archlinuxcn/lilac/pull/170, https://github.com/archlinuxcn/lilac/pull/171

@lilydjwg I bundled [build-cleaner](https://github.com/archlinuxcn/misc_scripts/blob/master/build-cleaner) in this package as it seems the simplest way. As you're the only contributor for that script, could you go ahead and declare a license for it?