### PR TITLE
addpkg: dhcptest-git

### DIFF
--- a/archlinuxcn/dhcptest-git/PKGBUILD
+++ b/archlinuxcn/dhcptest-git/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Yen Chi Hsuan <yan12125 at gmail dot com>
+
+_pkgname=dhcptest
+pkgname=$_pkgname-git
+pkgver=0.7.r14.g8e753fa
+pkgrel=1
+pkgdesc="DHCP test client"
+arch=('i686' 'x86_64')
+url="https://github.com/CyberShadow/dhcptest"
+license=('Boost')
+depends=('glibc' 'gcc-libs')
+makedepends=('dmd' 'git')
+source=("$_pkgname"::"git+https://github.com/CyberShadow/dhcptest")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  # Use the tag of the last commit
+  git describe --long --tags | sed -E 's/([^-]*-g)/r\1/;s/-/./g'
+}
+
+build() {
+  cd "$srcdir/$_pkgname"
+  dmd dhcptest.d
+}
+
+package() {
+  cd "$srcdir/$_pkgname"
+  install -Dm755 "dhcptest" "$pkgdir/usr/bin/dhcptest"
+  install -Dm644 "README.md" "$pkgdir/usr/share/doc/dhcptest/README.md"
+}
+

--- a/archlinuxcn/dhcptest-git/lilac.yaml
+++ b/archlinuxcn/dhcptest-git/lilac.yaml
@@ -1,0 +1,13 @@
+maintainers:
+  - github: YuutaW
+    email: trumeetc@gmail.com
+
+build_prefix: extra-x86_64
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: dhcptest-git

--- a/archlinuxcn/dhcptest-git/lilac.yaml
+++ b/archlinuxcn/dhcptest-git/lilac.yaml
@@ -11,3 +11,5 @@ post_build: aur_post_build
 update_on:
   - source: aur
     aur: dhcptest-git
+  - source: github
+    github: CyberShadow/dhcptest


### PR DESCRIPTION
`dhcptest-git` is a useful tool of testing DHCP servers and viewing their responses.