### PR TITLE
Update glmark2 package and hook

### DIFF
--- a/archlinuxcn/glmark2/PKGBUILD
+++ b/archlinuxcn/glmark2/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: farseerfc <farseerfc@gmail.com>
 
 pkgname=glmark2
-pkgver=2014.03
-pkgrel=3
+pkgver=2020.04
+pkgrel=1
 pkgdesc="OpenGL (ES) 2.0 benchmark"
 arch=('i686' 'x86_64')
 url="https://launchpad.net/glmark2"
@@ -11,17 +11,11 @@ groups=()
 depends=('libjpeg-turbo' 'libpng' 'libx11' 'libxcb' 'libgl' 'python2')
 makedepends=()
 optdepends=()
-source=("https://launchpad.net/glmark2/trunk/$pkgver/+download/$pkgname-$pkgver.tar.gz"
-        'pr24.patch::https://patch-diff.githubusercontent.com/raw/glmark2/glmark2/pull/24.patch'
-        'libpng16.patch::https://github.com/glmark2/glmark2/commit/499aa81a68fb4c8aac1c80f0d6a4cce05941c4cc.patch')
-md5sums=('739859cf57d4c8a23452c43e84f66e56'
-         '108cbcdf594782dbdcb5908f68db86d7'
-         'e1e498bbaf059a1ce886999b25e6ed78')
+source=("https://github.com/glmark2/glmark2/archive/$pkgver.tar.gz")
+md5sums=('a90713700a740180fef3576f7ee3c9db')
 
 prepare(){
   cd "$srcdir/$pkgname-$pkgver"
-  patch -p1 <../pr24.patch
-  patch -p1 <../libpng16.patch
   sed -i "s|-Werror ||g" wscript
 }
 

--- a/archlinuxcn/glmark2/lilac.yaml
+++ b/archlinuxcn/glmark2/lilac.yaml
@@ -12,3 +12,6 @@ post_build: aur_post_build
 update_on:
   - source: aur
     aur: glmark2
+  - source: github
+    github: glmark2/glmark2
+    use_latest_release: true


### PR DESCRIPTION
Seems that `glmark2` has a tagged release on GH at 2020.04 that has included the two patches.