### PR TITLE
addpkg: nix

### DIFF
--- a/archlinuxcn/archlinux-nix/lilac.yaml
+++ b/archlinuxcn/archlinux-nix/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: berberman
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: archlinux-nix

--- a/archlinuxcn/editline/lilac.yaml
+++ b/archlinuxcn/editline/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: berberman
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: editline

--- a/archlinuxcn/nix/lilac.yaml
+++ b/archlinuxcn/nix/lilac.yaml
@@ -1,0 +1,13 @@
+maintainers:
+  - github: berberman
+
+pre_build: aur_pre_build
+
+post_build: aur_post_build
+
+repo_depends:
+  - editline
+
+update_on:
+  - source: aur
+    aur: nix


### PR DESCRIPTION
nix can be used as an external package manager on Arch Linux.