### PR TITLE
feat: optimus-manager@1.4-1 with fixes

### DIFF
--- a/archlinuxcn/optimus-manager/PKGBUILD
+++ b/archlinuxcn/optimus-manager/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Robin Lange <robin dot langenc at gmail dot com>
-# Contributor: Robin Lange <robin dot langenc at gmail dot com>
+
 pkgname=optimus-manager
-pkgver=1.3.1
-pkgrel=2
+pkgver=1.4
+pkgrel=1
 pkgdesc="Management utility to handle GPU switching for Optimus laptops"
 arch=('any')
 url="https://github.com/Askannz/optimus-manager"
@@ -14,10 +14,13 @@ optdepends=('bbswitch: alternative power switching method'
             'acpi_call: alternative power switching method'
             'xf86-video-intel: provides the Xorg intel driver')
 makedepends=('python-setuptools' 'git')
-backup=('etc/optimus-manager/xorg-intel.conf'
-        'etc/optimus-manager/xorg-nvidia.conf'
+backup=('etc/optimus-manager/xorg/integrated-mode/integrated-gpu.conf'
+        'etc/optimus-manager/xorg/nvidia-mode/integrated-gpu.conf'
+        'etc/optimus-manager/xorg/nvidia-mode/nvidia-gpu.conf'
+        'etc/optimus-manager/xorg/hybrid-mode/integrated-gpu.conf'
+        'etc/optimus-manager/xorg/hybrid-mode/nvidia-gpu.conf'
 
-        'etc/optimus-manager/xsetup-intel.sh'
+        'etc/optimus-manager/xsetup-integrated.sh'
         'etc/optimus-manager/xsetup-nvidia.sh'
         'etc/optimus-manager/xsetup-hybrid.sh'
 
@@ -31,7 +34,7 @@ sha256sums=('SKIP')
 build() {
  
   cd "${srcdir}/optimus-manager/"
-  python3 setup.py build
+  /usr/bin/python3 setup.py build
  
 }
  
@@ -48,20 +51,25 @@ package() {
   install -Dm644 optimus-manager.conf "$pkgdir/usr/share/optimus-manager.conf"
   
   install -Dm644 systemd/logind/10-optimus-manager.conf "$pkgdir/usr/lib/systemd/logind.conf.d/10-optimus-manager.conf"
+  install -Dm755 systemd/suspend/optimus-manager.py "$pkgdir/usr/lib/systemd/system-sleep/optimus-manager.py"
+  
   
   install -Dm644 login_managers/sddm/20-optimus-manager.conf "$pkgdir/etc/sddm.conf.d/20-optimus-manager.conf"
   install -Dm644 login_managers/lightdm/20-optimus-manager.conf  "$pkgdir/etc/lightdm/lightdm.conf.d/20-optimus-manager.conf"
   
-  install -Dm644 config/xorg-intel.conf "$pkgdir/etc/optimus-manager/xorg-intel.conf"
-  install -Dm644 config/xorg-nvidia.conf "$pkgdir/etc/optimus-manager/xorg-nvidia.conf"
+  install -Dm644 config/xorg/integrated-mode/integrated-gpu.conf "$pkgdir/etc/optimus-manager/xorg/integrated-mode/integrated-gpu.conf"
+  install -Dm644 config/xorg/nvidia-mode/nvidia-gpu.conf "$pkgdir/etc/optimus-manager/xorg/nvidia-mode/nvidia-gpu.conf"
+  install -Dm644 config/xorg/nvidia-mode/integrated-gpu.conf "$pkgdir/etc/optimus-manager/xorg/nvidia-mode/integrated-gpu.conf"
+  install -Dm644 config/xorg/hybrid-mode/integrated-gpu.conf "$pkgdir/etc/optimus-manager/xorg/hybrid-mode/integrated-gpu.conf"
+  install -Dm644 config/xorg/hybrid-mode/nvidia-gpu.conf "$pkgdir/etc/optimus-manager/xorg/hybrid-mode/nvidia-gpu.conf"
   
-  install -Dm755 config/xsetup-intel.sh "$pkgdir/etc/optimus-manager/xsetup-intel.sh"
   install -Dm755 config/xsetup-nvidia.sh "$pkgdir/etc/optimus-manager/xsetup-nvidia.sh"
   install -Dm755 config/xsetup-hybrid.sh "$pkgdir/etc/optimus-manager/xsetup-hybrid.sh"
+  install -Dm755 config/xsetup-integrated.sh "$pkgdir/etc/optimus-manager/xsetup-integrated.sh"
 
   install -Dm755 config/nvidia-enable.sh "$pkgdir/etc/optimus-manager/nvidia-enable.sh"
   install -Dm755 config/nvidia-disable.sh "$pkgdir/etc/optimus-manager/nvidia-disable.sh"
  
-  python3 setup.py install --root="$pkgdir/" --optimize=1 --skip-build
+  /usr/bin/python3 setup.py install --root="$pkgdir/" --optimize=1 --skip-build
  
 } 

--- a/archlinuxcn/optimus-manager/lilac.py
+++ b/archlinuxcn/optimus-manager/lilac.py
@@ -2,14 +2,18 @@
 
 from lilaclib import *
 
+
 def pre_build():
     aur_pre_build()
     pattern = re.compile("['\"]?python-setuptools['\"]? ?")
     for line in edit_file('PKGBUILD'):
         if line.startswith('depends='):
             print(pattern.sub('', line))
+        elif "xsetup-intel.sh" in line:
+            print("")
         else:
             print(line)
+
 
 def post_build():
     aur_post_build()


### PR DESCRIPTION
optimus-manager@1.4-1 is up on AUR, but the stock PKGBUILD is not working. This change updated the PKGBUILD as well as the patch in `lilac.py`.

BTW, buildlog: <https://build.archlinuxcn.org/packages/#/optimus-manager/logs/1614492157>