### PR TITLE
addpkg: nerdctl

### DIFF
--- a/archlinuxcn/buildkit/PKGBUILD
+++ b/archlinuxcn/buildkit/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Songmin Li <lisongmin@protonmail.com>
+pkgname=buildkit
+pkgver=0.8.2
+pkgrel=1
+pkgdesc='BuildKit is a toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.'
+makedepends=('go')
+arch=('i686' 'x86_64' 'aarch64')
+url='https://github.com/moby/buildkit'
+license=('Apache')
+provides=('buildkit')
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/moby/${pkgname}/archive/v${pkgver}.tar.gz)
+sha256sums=('bfe402c521a461903088dfccb5b75fcc6811f7c416e041c3c60af7a2400866bc')
+
+build() {
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+  export GO111MODULE=on
+
+  cd $pkgname-${pkgver}
+
+  sed -i 's/^\(.*Version =\) ".*"$/\1 "'${pkgver}'"/g' version/version.go
+  sed -i 's/^\(.*Revision =\) ".*"$/\1 "'${pkgrel}'"/g' version/version.go
+
+  go build -v github.com/moby/buildkit/cmd/buildctl
+  go build -v github.com/moby/buildkit/cmd/buildkitd
+}
+
+package() {
+  # Install binary
+  export DESTDIR=$pkgdir
+  export BINDIR=/usr/bin
+
+  cd $srcdir/${pkgname}-${pkgver}
+  install -Dm755 buildctl ${pkgdir}/usr/bin/buildctl
+  install -Dm755 buildkitd ${pkgdir}/usr/bin/buildkitd
+}

--- a/archlinuxcn/buildkit/PKGBUILD
+++ b/archlinuxcn/buildkit/PKGBUILD
@@ -2,8 +2,9 @@
 pkgname=buildkit
 pkgver=0.8.2
 pkgrel=1
-pkgdesc='BuildKit is a toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.'
+pkgdesc='A toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.'
 makedepends=('go')
+depends=('glibc')
 arch=('i686' 'x86_64' 'aarch64')
 url='https://github.com/moby/buildkit'
 license=('Apache')

--- a/archlinuxcn/buildkit/lilac.py
+++ b/archlinuxcn/buildkit/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from lilaclib import *
+
+
+def pre_build():
+    update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+    run_cmd(['updpkgsums'])
+
+
+def post_build():
+    git_add_files('PKGBUILD')
+    git_commit()
+
+# if __name__ == '__main__':
+#        single_main()

--- a/archlinuxcn/buildkit/lilac.py
+++ b/archlinuxcn/buildkit/lilac.py
@@ -5,7 +5,6 @@ from lilaclib import *
 
 def pre_build():
     update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
-    run_cmd(['updpkgsums'])
 
 
 def post_build():

--- a/archlinuxcn/buildkit/lilac.yaml
+++ b/archlinuxcn/buildkit/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: lisongmin
+    email: lisongmin@protonmail.com
+
+build_prefix: extra-x86_64
+
+update_on:
+  - source: github
+    github: moby/buildkit
+    use_latest_release: true

--- a/archlinuxcn/nerdctl/PKGBUILD
+++ b/archlinuxcn/nerdctl/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=nerdctl
 pkgver=0.7.2
 pkgrel=1
-pkgdesc='nerdctl is a Docker-compatible CLI for containerd.'
+pkgdesc='Docker-compatible CLI for containerd.'
 makedepends=('go')
 arch=('i686' 'x86_64' 'aarch64')
 url='https://github.com/containerd/nerdctl'

--- a/archlinuxcn/nerdctl/PKGBUILD
+++ b/archlinuxcn/nerdctl/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Songmin Li <lisongmin@protonmail.com>
+pkgname=nerdctl
+pkgver=0.7.2
+pkgrel=1
+pkgdesc='nerdctl is a Docker-compatible CLI for containerd.'
+makedepends=('go')
+arch=('i686' 'x86_64' 'aarch64')
+url='https://github.com/containerd/nerdctl'
+license=('Apache')
+provides=('nerdctl')
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/containerd/${pkgname}/archive/v${pkgver}.tar.gz)
+sha256sums=('0bf1badd8daf4d86063504539cf645017195cb053c40f61c1cc2f2b2875a65f8')
+
+build() {
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+  export GO111MODULE=on
+
+  cd $pkgname-${pkgver}
+
+  sed -i 's/^\(.*Version =\) ".*"$/\1 "'${pkgver}'"/g' pkg/version/version.go
+  sed -i 's/^\(.*Revision =\) ".*"$/\1 "'${pkgrel}'"/g' pkg/version/version.go
+
+  go build -o nerdctl
+
+  ./nerdctl completion bash > nerdctl.bash
+}
+
+package() {
+  depends=('containerd' 'cni-plugins' 'buildkit' 'rootlesskit' 'slirp4netns')
+
+  # Install binary
+  install -Dm755 "$srcdir/${pkgname}-${pkgver}/nerdctl" "$pkgdir/usr/bin/nerdctl"
+  install -Dm755 "$srcdir/${pkgname}-${pkgver}/extras/rootless/containerd-rootless-setuptool.sh" "$pkgdir/usr/bin/containerd-rootless-setuptool.sh"
+  install -Dm755 "$srcdir/${pkgname}-${pkgver}/extras/rootless/containerd-rootless.sh" "$pkgdir/usr/bin/containerd-rootless.sh"
+
+  # completion for bash
+  install -Dm644 "$srcdir/${pkgname}-${pkgver}/nerdctl.bash" "$pkgdir/usr/share/bash-completion/completions/nerdctl"
+}

--- a/archlinuxcn/nerdctl/lilac.py
+++ b/archlinuxcn/nerdctl/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from lilaclib import *
+
+
+def pre_build():
+    update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+    run_cmd(['updpkgsums'])
+
+
+def post_build():
+    git_add_files('PKGBUILD')
+    git_commit()
+
+# if __name__ == '__main__':
+#        single_main()

--- a/archlinuxcn/nerdctl/lilac.py
+++ b/archlinuxcn/nerdctl/lilac.py
@@ -5,7 +5,6 @@ from lilaclib import *
 
 def pre_build():
     update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
-    run_cmd(['updpkgsums'])
 
 
 def post_build():

--- a/archlinuxcn/nerdctl/lilac.yaml
+++ b/archlinuxcn/nerdctl/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: lisongmin
+    email: lisongmin@protonmail.com
+
+build_prefix: extra-x86_64
+
+update_on:
+  - source: github
+    github: containerd/nerdctl
+    use_latest_release: true

--- a/archlinuxcn/rootlesskit/PKGBUILD
+++ b/archlinuxcn/rootlesskit/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Songmin Li <lisongmin@protonmail.com>
+pkgname=rootlesskit
+pkgver=0.14.0
+pkgrel=1
+pkgdesc='RootlessKit is a Linux-native implementation of "fake root" using user_namespaces.'
+makedepends=('go')
+arch=('i686' 'x86_64' 'aarch64')
+url='https://github.com/rootless-containers/rootlesskit'
+license=('Apache')
+provides=('rootlesskit')
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/rootless-containers/${pkgname}/archive/v${pkgver}.tar.gz)
+sha256sums=('63c43f205e38f9f6e19c535323abef6f4e01293e4d2241991c3b8a78d1f50bef')
+
+build() {
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+  export GO111MODULE=on
+
+  cd $pkgname-${pkgver}
+
+  make all
+}
+
+package() {
+  # Install binary
+  export DESTDIR=$pkgdir
+  export BINDIR=/usr/bin
+
+  cd $srcdir/${pkgname}-${pkgver}
+  make install
+}

--- a/archlinuxcn/rootlesskit/PKGBUILD
+++ b/archlinuxcn/rootlesskit/PKGBUILD
@@ -2,7 +2,8 @@
 pkgname=rootlesskit
 pkgver=0.14.0
 pkgrel=1
-pkgdesc='RootlessKit is a Linux-native implementation of "fake root" using user_namespaces.'
+pkgdesc='A Linux-native implementation of "fake root" using user_namespaces.'
+depends=('glibc')
 makedepends=('go')
 arch=('i686' 'x86_64' 'aarch64')
 url='https://github.com/rootless-containers/rootlesskit'

--- a/archlinuxcn/rootlesskit/lilac.py
+++ b/archlinuxcn/rootlesskit/lilac.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+from lilaclib import *
+
+
+def pre_build():
+    update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+    run_cmd(['updpkgsums'])
+
+
+def post_build():
+    git_add_files('PKGBUILD')
+    git_commit()
+
+# if __name__ == '__main__':
+#        single_main()

--- a/archlinuxcn/rootlesskit/lilac.py
+++ b/archlinuxcn/rootlesskit/lilac.py
@@ -5,7 +5,6 @@ from lilaclib import *
 
 def pre_build():
     update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
-    run_cmd(['updpkgsums'])
 
 
 def post_build():

--- a/archlinuxcn/rootlesskit/lilac.yaml
+++ b/archlinuxcn/rootlesskit/lilac.yaml
@@ -1,0 +1,10 @@
+maintainers:
+  - github: lisongmin
+    email: lisongmin@protonmail.com
+
+build_prefix: extra-x86_64
+
+update_on:
+  - source: github
+    github: rootless-containers/rootlesskit
+    use_latest_release: true


### PR DESCRIPTION

`nerdctl` 是 `containerd` 的命令行终端，提供兼容`docker`的命令行参数。

这个PR主要是打包 [nerdctl](https://github.com/containerd/nerdctl) 以及它的依赖包

* [buildkit](https://github.com/moby/buildkit)  用于`nerdctl build`
* [rootlesskit](https://github.com/rootless-containers/rootlesskit) 用于在非root用户下使用`nerdctl`