### PR TITLE
sendanywhere: skip validity check

### DIFF
--- a/archlinuxcn/sendanywhere/PKGBUILD
+++ b/archlinuxcn/sendanywhere/PKGBUILD
@@ -16,7 +16,7 @@ depends=('electron8')
 makedepends=('asar')
 
 source=("https://update.send-anywhere.com/linux_downloads/sendanywhere_latest_amd64.deb" "LICENSE")
-sha512sums=('1da80fa5f054dcb2a0d7717c1544baff884164d933d643dca52d1bda677bd989bb676f20e19db64f629d7d6324af430f192a52dad2868d6dad4ae978ed6871e7'
+sha512sums=('SKIP'
             'aeb97a12f246d78cbf202354148b429a037997d68087bceed5d5ce5036443d779c2535138b54347579ddf05994a61b9333913f9261733f367d02e0e9cf7d0b5e')
 # If validity check fails, please leave a comment to remind me to update the package version
 


### PR DESCRIPTION
fix according to #2108 
> `vcs_update` expects them to be `SKIP`.