### PR TITLE
zsh-syntax-highlighting-git: update AUR package after build

### DIFF
--- a/archlinuxcn/zsh-syntax-highlighting-git/PKGBUILD
+++ b/archlinuxcn/zsh-syntax-highlighting-git/PKGBUILD
@@ -1,27 +1,43 @@
-# Maintainer: Sam Stuewe <halosghost at archlinux dot info>
+# Maintainer: DDoSolitary <DDoSolitary@gmail.com>
+# Contributor: Amanoel Dawod <amoka at amanoel dot com>
+# Contributor: Sam Stuewe <halosghost at archlinux dot info>
 # Contributor: mjheagle <mjheagle8@gmail.com>
-_name='zsh-syntax-highlighting'
-pkgname="${_name}-git"
-pkgver=0.8.0.alpha1.pre.redrawhook.r50.gebef4e5
+
+_pkgname=zsh-syntax-highlighting
+pkgname="${_pkgname}-git"
+pkgver=0.8.0.alpha1.pre.redrawhook.r46.g5eb4948
 pkgrel=1
-pkgdesc='Fish shell like syntax highlighting for Zsh'
-url='https://github.com/zsh-users/zsh-syntax-highlighting'
+pkgdesc="Fish shell like syntax highlighting for Zsh (from git)"
 arch=('any')
-license=('Custom')
+url="https://github.com/zsh-users/zsh-syntax-highlighting"
+license=('BSD')
 depends=('zsh>=4.3.9')
 makedepends=('git')
-provides=('zsh-syntax-highlighting')
-conflicts=('zsh-syntax-highlighting')
-install="${_name}.install"
-source=("${_name}::${url//https/git}")
+provides=($_pkgname)
+conflicts=($_pkgname)
+install="${_pkgname}.install"
+source=("git+$url.git")
 sha256sums=('SKIP')
 
 pkgver() {
-   cd "${srcdir}/${_name}"
-   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  cd $_pkgname
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $_pkgname
+  make
 }
 
 package() {
-    cd "${srcdir}/${_name}"
-    make DESTDIR="${pkgdir}" PREFIX='/usr' install
+  cd $_pkgname
+  make PREFIX="/usr" SHARE_DIR="${pkgdir}/usr/share/zsh/plugins/$_pkgname" DESTDIR="${pkgdir}" install
+  # create symlink for using with oh-my-zsh
+  ln -s "zsh-syntax-highlighting.zsh" \
+       "${pkgdir}/usr/share/zsh/plugins/$_pkgname/zsh-syntax-highlighting.plugin.zsh"
+
+  # licence
+  install -dm755 "${pkgdir}/usr/share/licenses/$_pkgname"
+  ln -s "/usr/share/doc/$_pkgname/COPYING.md" \
+        "${pkgdir}/usr/share/licenses/$_pkgname/COPYING"
 }

--- a/archlinuxcn/zsh-syntax-highlighting-git/lilac.py
+++ b/archlinuxcn/zsh-syntax-highlighting-git/lilac.py
@@ -1,13 +1,8 @@
-# Trimmed lilac.py
 from lilaclib import *
 
-#build_prefix = 'extra-x86_64'
-
-#pre_build = vcs_update
+def pre_build():
+  vcs_update()
 
 def post_build():
-  git_add_files('PKGBUILD')
-  git_commit()
-
-#if __name__ == '__main__':
-#  single_main()
+  git_pkgbuild_commit()
+  update_aur_repo()

--- a/archlinuxcn/zsh-syntax-highlighting-git/lilac.yaml
+++ b/archlinuxcn/zsh-syntax-highlighting-git/lilac.yaml
@@ -3,10 +3,9 @@
 maintainers:
   - github: Xuanwo
     email: xuanwo@archlinuxcn.org
+  - github: DDoSolitary
 
 build_prefix: extra-x86_64
-
-pre_build: vcs_update
 
 update_on:
   - source: github

--- a/archlinuxcn/zsh-syntax-highlighting-git/zsh-syntax-highlighting.install
+++ b/archlinuxcn/zsh-syntax-highlighting-git/zsh-syntax-highlighting.install
@@ -1,4 +1,8 @@
 post_install() {
-    echo "==> To use syntax highlighting, include the following line in your .zshrc:
-    source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+  cat << EOF
+To activate zsh-syntax-highlighting, add the following line at the end of ~/.zshrc:
+    source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+EOF
 }
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The AUR package is unfortunatedly orphaned, so I adopted that package and I think it's a good idea to update it with lilac.