### PR TITLE
gnome-control-center-nocheese & libwacom-surface

### DIFF
--- a/archlinuxcn/gnome-control-center-nocheese/PKGBUILD
+++ b/archlinuxcn/gnome-control-center-nocheese/PKGBUILD
@@ -1,0 +1,65 @@
+# Maintainer: Daniel Peukert <daniel@peukert.cc>
+# Contributor: Taijian <taijian@posteo.de>
+# Contributor: Alberto Casademunt <alberto.casademunt at protonmail dot ch>
+# Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org> (gnome-control-center PKGBUILD)
+# Contributor: Jan de Groot <jgc@archlinux.org> (gnome-control-center PKGBUILD)
+_pkgname='gnome-control-center'
+pkgname="$_pkgname-nocheese"
+pkgver='40.0'
+_gvccommit='7a621180b46421e356b33972e3446775a504139c'
+pkgrel='1'
+pkgdesc="GNOME's main interface to configure various aspects of the desktop - without Cheese dependency"
+arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h' 'aarch64')
+url="https://gitlab.gnome.org/GNOME/$_pkgname"
+license=('GPL2')
+groups=('gnome')
+depends=(
+	'accountsservice' 'bolt' 'colord-gtk' 'cups-pk-helper' 'gnome-bluetooth'
+	'gnome-color-manager' 'gnome-desktop' 'gnome-online-accounts'
+	'gnome-settings-daemon' 'grilo' 'gsettings-desktop-schemas' 'gsound' 'gtk3'
+	'libgnomekbd' 'libgtop' 'libgudev' 'libhandy' 'libibus' 'libmm-glib'
+	'libpwquality' 'nm-connection-editor' 'smbclient' 'sound-theme-freedesktop'
+	'udisks2' 'upower'
+)
+optdepends=(
+	'gnome-user-share: WebDAV file sharing'
+	'gnome-remote-desktop: screen sharing'
+	'openssh: remote login'
+	'rygel: media sharing'
+	'system-config-printer: Printer settings'
+)
+makedepends=('docbook-xsl' 'meson' 'modemmanager' 'python')
+checkdepends=('python-dbusmock' 'python-gobject' 'xorg-server-xvfb')
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+source=(
+	"$pkgname-$pkgver-$pkgrel.tar.gz::$url/-/archive/$pkgver/$_pkgname-$pkgver.tar.gz"
+	"$pkgname-$pkgver-$pkgrel-gvc.tar.gz::https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/archive/$_gvccommit/libgnome-volume-control-$_gvccommit.tar.gz"
+)
+sha256sums=('dbcae924bb45118b0448057441854f1bcffd357f729f2d043d62446b9909fa98'
+            '0bd8bb754ce3fb82b29c83e2186b2a84517be772acdba28d15eb928a44cadec3')
+
+_sourcedirectory="$_pkgname-$pkgver"
+
+prepare() {
+	cd "$srcdir/$_sourcedirectory/"
+	rm -rf 'subprojects/gvc/'
+	mv "../libgnome-volume-control-$_gvccommit/" 'subprojects/gvc/'
+}
+
+build() {
+	cd "$srcdir/$_sourcedirectory/"
+	arch-meson "$srcdir/$_sourcedirectory/" build -D documentation=true -D cheese=false
+	meson compile -C build
+}
+
+check() {
+	cd "$srcdir/$_sourcedirectory/"
+	meson test -C build --print-errorlogs
+}
+
+package() {
+	cd "$srcdir/$_sourcedirectory/"
+	DESTDIR="$pkgdir" meson install -C build
+	install -d -o root -g 102 -m 750 "$pkgdir/usr/share/polkit-1/rules.d"
+}

--- a/archlinuxcn/gnome-control-center-nocheese/lilac.yaml
+++ b/archlinuxcn/gnome-control-center-nocheese/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+    - github: SamLukeYes
+
+build_prefix: extra-x86_64
+
+pre_build_script: aur_pre_build(maintainers=['dpeukert'])
+
+post_build: aur_post_build
+
+update_on:
+    - source: aur
+      aur: gnome-control-center-nocheese

--- a/archlinuxcn/libwacom-surface/0001-Add-support-for-BUS_VIRTUAL.patch
+++ b/archlinuxcn/libwacom-surface/0001-Add-support-for-BUS_VIRTUAL.patch
@@ -1,0 +1,105 @@
+From c0eaf576f68b2a34136a7c1c3977ff8531d37504 Mon Sep 17 00:00:00 2001
+From: Dorian Stoll <dorian.stoll@tmsp.io>
+Date: Sat, 27 Jun 2020 18:21:11 +0200
+Subject: [PATCH 01/11] Add support for BUS_VIRTUAL
+
+This is needed to support IPTS devices through the iptsd userspace
+daemon. It exposes the touchscreen / stylus as uinput, since the parsing
+of raw IPTS data needs to happen in userspace.
+
+Because these devices are not backed by an actual bus, they are created
+as BUS_VIRTUAL.
+
+Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
+---
+ data/test_data_files.py      | 2 +-
+ libwacom/libwacom-database.c | 4 ++++
+ libwacom/libwacom.c          | 5 +++++
+ libwacom/libwacom.h          | 1 +
+ test/test-tablet-validity.c  | 1 +
+ 5 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/data/test_data_files.py b/data/test_data_files.py
+index 5acdbac..cb5ca6d 100755
+--- a/data/test_data_files.py
++++ b/data/test_data_files.py
+@@ -29,6 +29,6 @@ def test_device_match(tabletfile):
+             continue
+ 
+         bus, vid, pid = match.split(':')[:3]  # skip the name part of the match
+-        assert bus in ['usb', 'bluetooth', 'i2c', 'serial'], f'{tabletfile}: unknown bus type'
++        assert bus in ['usb', 'bluetooth', 'i2c', 'serial', 'virt'], f'{tabletfile}: unknown bus type'
+         assert re.match('[0-9a-f]{4}', vid), f'{tabletfile}: {vid} must be lowercase hex'
+         assert re.match('[0-9a-f]{4}', pid), f'{tabletfile}: {pid} must be lowercase hex'
+diff --git a/libwacom/libwacom-database.c b/libwacom/libwacom-database.c
+index d57ef2d..17571b6 100644
+--- a/libwacom/libwacom-database.c
++++ b/libwacom/libwacom-database.c
+@@ -130,6 +130,8 @@ bus_from_str (const char *str)
+ 		return WBUSTYPE_BLUETOOTH;
+ 	if (streq(str, "i2c"))
+ 		return WBUSTYPE_I2C;
++	if (streq(str, "virt"))
++		return WBUSTYPE_VIRTUAL;
+ 	return WBUSTYPE_UNKNOWN;
+ }
+ 
+@@ -148,6 +150,8 @@ bus_to_str (WacomBusType bus)
+ 		return "bluetooth";
+ 	case WBUSTYPE_I2C:
+ 		return "i2c";
++	case WBUSTYPE_VIRTUAL:
++		return "virt";
+ 	}
+ 	g_assert_not_reached ();
+ }
+diff --git a/libwacom/libwacom.c b/libwacom/libwacom.c
+index 062b313..7b97bb1 100644
+--- a/libwacom/libwacom.c
++++ b/libwacom/libwacom.c
+@@ -147,6 +147,10 @@ get_bus_vid_pid (GUdevDevice  *device,
+ 		*bus = WBUSTYPE_I2C;
+ 		retval = TRUE;
+ 		break;
++	case 6:
++		*bus = WBUSTYPE_VIRTUAL;
++		retval = TRUE;
++		break;
+ 	}
+ 
+ out:
+@@ -765,6 +769,7 @@ static void print_match(int fd, const WacomMatch *match)
+ 		case WBUSTYPE_USB:		bus_name = "usb";	break;
+ 		case WBUSTYPE_SERIAL:		bus_name = "serial";	break;
+ 		case WBUSTYPE_I2C:		bus_name = "i2c";	break;
++		case WBUSTYPE_VIRTUAL:		bus_name = "virt";	break;
+ 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
+ 		default:			g_assert_not_reached(); break;
+ 	}
+diff --git a/libwacom/libwacom.h b/libwacom/libwacom.h
+index 1b9bc2c..24e99cd 100644
+--- a/libwacom/libwacom.h
++++ b/libwacom/libwacom.h
+@@ -117,6 +117,7 @@ typedef enum {
+ 	WBUSTYPE_SERIAL,	/**< Serial tablet */
+ 	WBUSTYPE_BLUETOOTH,	/**< Bluetooth tablet */
+ 	WBUSTYPE_I2C,		/**< I2C tablet */
++	WBUSTYPE_VIRTUAL,	/**< Virtual (uinput) tablet */
+ } WacomBusType;
+ 
+ /**
+diff --git a/test/test-tablet-validity.c b/test/test-tablet-validity.c
+index 9e5b02f..3883341 100644
+--- a/test/test-tablet-validity.c
++++ b/test/test-tablet-validity.c
+@@ -179,6 +179,7 @@ assert_vidpid(WacomBusType bus, int vid, int pid)
+ 			break;
+ 		case WBUSTYPE_BLUETOOTH:
+ 		case WBUSTYPE_I2C:
++		case WBUSTYPE_VIRTUAL:
+ 			g_assert_cmpint(vid, >, 0);
+ 			g_assert_cmpint(pid, >, 0);
+ 			break;
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0002-Add-support-for-Intel-Management-Engine-bus.patch
+++ b/archlinuxcn/libwacom-surface/0002-Add-support-for-Intel-Management-Engine-bus.patch
@@ -1,0 +1,100 @@
+From 02df4e0f272dff001ee280ab93e8e1c4600375ff Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sat, 1 Jun 2019 21:17:15 +0200
+Subject: [PATCH 02/11] Add support for Intel Management Engine bus
+
+Add support for devices connected via the Intel Management Engine (MEI).
+This is required to support IPTS based devices, such as (among others)
+the Microsoft Surface Books, Surface Pro 5 and 6, and Surface Laptops.
+---
+ data/test_data_files.py      | 2 +-
+ libwacom/libwacom-database.c | 4 ++++
+ libwacom/libwacom.c          | 5 +++++
+ libwacom/libwacom.h          | 1 +
+ test/test-tablet-validity.c  | 1 +
+ 5 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/data/test_data_files.py b/data/test_data_files.py
+index cb5ca6d..466b18a 100755
+--- a/data/test_data_files.py
++++ b/data/test_data_files.py
+@@ -29,6 +29,6 @@ def test_device_match(tabletfile):
+             continue
+ 
+         bus, vid, pid = match.split(':')[:3]  # skip the name part of the match
+-        assert bus in ['usb', 'bluetooth', 'i2c', 'serial', 'virt'], f'{tabletfile}: unknown bus type'
++        assert bus in ['usb', 'bluetooth', 'i2c', 'serial', 'virt', 'mei'], f'{tabletfile}: unknown bus type'
+         assert re.match('[0-9a-f]{4}', vid), f'{tabletfile}: {vid} must be lowercase hex'
+         assert re.match('[0-9a-f]{4}', pid), f'{tabletfile}: {pid} must be lowercase hex'
+diff --git a/libwacom/libwacom-database.c b/libwacom/libwacom-database.c
+index 17571b6..4c6df4e 100644
+--- a/libwacom/libwacom-database.c
++++ b/libwacom/libwacom-database.c
+@@ -132,6 +132,8 @@ bus_from_str (const char *str)
+ 		return WBUSTYPE_I2C;
+ 	if (streq(str, "virt"))
+ 		return WBUSTYPE_VIRTUAL;
++	if (strcmp (str, "mei") == 0)
++		return WBUSTYPE_MEI;
+ 	return WBUSTYPE_UNKNOWN;
+ }
+ 
+@@ -152,6 +154,8 @@ bus_to_str (WacomBusType bus)
+ 		return "i2c";
+ 	case WBUSTYPE_VIRTUAL:
+ 		return "virt";
++	case WBUSTYPE_MEI:
++		return "mei";
+ 	}
+ 	g_assert_not_reached ();
+ }
+diff --git a/libwacom/libwacom.c b/libwacom/libwacom.c
+index 7b97bb1..d84e8fa 100644
+--- a/libwacom/libwacom.c
++++ b/libwacom/libwacom.c
+@@ -151,6 +151,10 @@ get_bus_vid_pid (GUdevDevice  *device,
+ 		*bus = WBUSTYPE_VIRTUAL;
+ 		retval = TRUE;
+ 		break;
++	case 68:
++		*bus = WBUSTYPE_MEI;
++		retval = TRUE;
++		break;
+ 	}
+ 
+ out:
+@@ -770,6 +774,7 @@ static void print_match(int fd, const WacomMatch *match)
+ 		case WBUSTYPE_SERIAL:		bus_name = "serial";	break;
+ 		case WBUSTYPE_I2C:		bus_name = "i2c";	break;
+ 		case WBUSTYPE_VIRTUAL:		bus_name = "virt";	break;
++		case WBUSTYPE_MEI:		bus_name = "mei";	break;
+ 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
+ 		default:			g_assert_not_reached(); break;
+ 	}
+diff --git a/libwacom/libwacom.h b/libwacom/libwacom.h
+index 24e99cd..0eee2fd 100644
+--- a/libwacom/libwacom.h
++++ b/libwacom/libwacom.h
+@@ -118,6 +118,7 @@ typedef enum {
+ 	WBUSTYPE_BLUETOOTH,	/**< Bluetooth tablet */
+ 	WBUSTYPE_I2C,		/**< I2C tablet */
+ 	WBUSTYPE_VIRTUAL,	/**< Virtual (uinput) tablet */
++	WBUSTYPE_MEI,		/**< MEI */
+ } WacomBusType;
+ 
+ /**
+diff --git a/test/test-tablet-validity.c b/test/test-tablet-validity.c
+index 3883341..352bc43 100644
+--- a/test/test-tablet-validity.c
++++ b/test/test-tablet-validity.c
+@@ -180,6 +180,7 @@ assert_vidpid(WacomBusType bus, int vid, int pid)
+ 		case WBUSTYPE_BLUETOOTH:
+ 		case WBUSTYPE_I2C:
+ 		case WBUSTYPE_VIRTUAL:
++		case WBUSTYPE_MEI:
+ 			g_assert_cmpint(vid, >, 0);
+ 			g_assert_cmpint(pid, >, 0);
+ 			break;
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0003-data-Add-Microsoft-Surface-pro-4.patch
+++ b/archlinuxcn/libwacom-surface/0003-data-Add-Microsoft-Surface-pro-4.patch
@@ -1,0 +1,33 @@
+From 29c9b7283741e717b61f07bdf14b678c13a6768d Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:18:55 +0200
+Subject: [PATCH 03/11] data: Add Microsoft Surface pro 4
+
+---
+ data/surface-pro4.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-pro4.tablet
+
+diff --git a/data/surface-pro4.tablet b/data/surface-pro4.tablet
+new file mode 100644
+index 0000000..1e0c67c
+--- /dev/null
++++ b/data/surface-pro4.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Pro 4
++
++[Device]
++Name=Microsoft Surface Pro 4
++Class=PenDisplay
++DeviceMatch=virt:1b96:006a;virt:1b96:0021;mei:1b96:006a;mei:1b96:0021
++Width=10
++Height=6
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0004-data-Add-Microsoft-Surface-pro-5.patch
+++ b/archlinuxcn/libwacom-surface/0004-data-Add-Microsoft-Surface-pro-5.patch
@@ -1,0 +1,33 @@
+From ccfc97812543a3db11a2c3dcd0ed25903730dfe3 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:19:02 +0200
+Subject: [PATCH 04/11] data: Add Microsoft Surface pro 5
+
+---
+ data/surface-pro5.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-pro5.tablet
+
+diff --git a/data/surface-pro5.tablet b/data/surface-pro5.tablet
+new file mode 100644
+index 0000000..b26af3a
+--- /dev/null
++++ b/data/surface-pro5.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Pro 5 (2017)
++
++[Device]
++Name=Microsoft Surface Pro 5
++Class=PenDisplay
++DeviceMatch=virt:1b96:001f;mei:1b96:001f
++Width=10
++Height=6
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0005-data-Add-Microsoft-Surface-pro-6.patch
+++ b/archlinuxcn/libwacom-surface/0005-data-Add-Microsoft-Surface-pro-6.patch
@@ -1,0 +1,33 @@
+From b378c3636c71c29470b8274de3e69f0fa3dbaa7e Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:19:07 +0200
+Subject: [PATCH 05/11] data: Add Microsoft Surface pro 6
+
+---
+ data/surface-pro6.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-pro6.tablet
+
+diff --git a/data/surface-pro6.tablet b/data/surface-pro6.tablet
+new file mode 100644
+index 0000000..e97fad8
+--- /dev/null
++++ b/data/surface-pro6.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Pro 6
++
++[Device]
++Name=Microsoft Surface Pro 6
++Class=PenDisplay
++DeviceMatch=virt:045e:001f;mei:045e:001f
++Width=10
++Height=6
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0006-data-Add-Microsoft-Surface-pro-7.patch
+++ b/archlinuxcn/libwacom-surface/0006-data-Add-Microsoft-Surface-pro-7.patch
@@ -1,0 +1,33 @@
+From 0b12a623e70d877fa6bf1df615d06229f7b2eb83 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:19:13 +0200
+Subject: [PATCH 06/11] data: Add Microsoft Surface pro 7
+
+---
+ data/surface-pro7.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-pro7.tablet
+
+diff --git a/data/surface-pro7.tablet b/data/surface-pro7.tablet
+new file mode 100644
+index 0000000..7961379
+--- /dev/null
++++ b/data/surface-pro7.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Pro 7
++
++[Device]
++Name=Microsoft Surface Pro 7
++Class=PenDisplay
++DeviceMatch=virt:045e:099f;mei:045e:099f
++Width=10
++Height=6
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=false
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0007-data-Add-Microsoft-Surface-Book.patch
+++ b/archlinuxcn/libwacom-surface/0007-data-Add-Microsoft-Surface-Book.patch
@@ -1,0 +1,33 @@
+From da5c0255ab397bc5537861f9b48d3036f2fc8e98 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:19:38 +0200
+Subject: [PATCH 07/11] data: Add Microsoft Surface Book
+
+---
+ data/surface-book.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-book.tablet
+
+diff --git a/data/surface-book.tablet b/data/surface-book.tablet
+new file mode 100644
+index 0000000..e2a5401
+--- /dev/null
++++ b/data/surface-book.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Book (1)
++
++[Device]
++Name=Microsoft Surface Book
++Class=PenDisplay
++DeviceMatch=virt:1b96:005e;mei:1b96:005e
++Width=11
++Height=7
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0008-data-Add-Microsoft-Surface-Book-2-13.5.patch
+++ b/archlinuxcn/libwacom-surface/0008-data-Add-Microsoft-Surface-Book-2-13.5.patch
@@ -1,0 +1,33 @@
+From 3779329faa2e5e4d974ef2ad92dee3e0a8c90888 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:20:04 +0200
+Subject: [PATCH 08/11] data: Add Microsoft Surface Book 2 (13.5")
+
+---
+ data/surface-book2-13.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-book2-13.tablet
+
+diff --git a/data/surface-book2-13.tablet b/data/surface-book2-13.tablet
+new file mode 100644
+index 0000000..b13cb07
+--- /dev/null
++++ b/data/surface-book2-13.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Book 2 13.5-inch model
++
++[Device]
++Name=Microsoft Surface Book 2 (13.5")
++Class=PenDisplay
++DeviceMatch=virt:045e:0021;mei:045e:0021
++Width=11
++Height=7
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0009-data-Add-Microsoft-Surface-Book-2-15.patch
+++ b/archlinuxcn/libwacom-surface/0009-data-Add-Microsoft-Surface-Book-2-15.patch
@@ -1,0 +1,33 @@
+From 13e81b74340251dba524b6f414e3452e93458929 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:20:13 +0200
+Subject: [PATCH 09/11] data: Add Microsoft Surface Book 2 (15")
+
+---
+ data/surface-book2-15.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-book2-15.tablet
+
+diff --git a/data/surface-book2-15.tablet b/data/surface-book2-15.tablet
+new file mode 100644
+index 0000000..ad98cc7
+--- /dev/null
++++ b/data/surface-book2-15.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Book 2 15-inch model
++
++[Device]
++Name=Microsoft Surface Book 2 (15")
++Class=PenDisplay
++DeviceMatch=virt:045e:0020;mei:045e:0020
++Width=12
++Height=8
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=true
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0010-data-Add-Microsoft-Surface-Book-3-13.5.patch
+++ b/archlinuxcn/libwacom-surface/0010-data-Add-Microsoft-Surface-Book-3-13.5.patch
@@ -1,0 +1,33 @@
+From 84f8519285c39cf3b35175f94a38cd48b3a7d922 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:20:29 +0200
+Subject: [PATCH 10/11] data: Add Microsoft Surface Book 3 (13.5")
+
+---
+ data/surface-book3-13.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-book3-13.tablet
+
+diff --git a/data/surface-book3-13.tablet b/data/surface-book3-13.tablet
+new file mode 100644
+index 0000000..a33c9cb
+--- /dev/null
++++ b/data/surface-book3-13.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Book 3 13.5-inch model
++
++[Device]
++Name=Microsoft Surface Book 3 (13.5")
++Class=PenDisplay
++DeviceMatch=virt:045e:09b2;mei:045e:09b2
++Width=11
++Height=7
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=false
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/0011-data-Add-Microsoft-Surface-Book-3-15.patch
+++ b/archlinuxcn/libwacom-surface/0011-data-Add-Microsoft-Surface-Book-3-15.patch
@@ -1,0 +1,33 @@
+From d105e4c6fd7512eefa4c703224a24cea19e0f457 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Tue, 18 Aug 2020 20:20:42 +0200
+Subject: [PATCH 11/11] data: Add Microsoft Surface Book 3 (15")
+
+---
+ data/surface-book3-15.tablet | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 data/surface-book3-15.tablet
+
+diff --git a/data/surface-book3-15.tablet b/data/surface-book3-15.tablet
+new file mode 100644
+index 0000000..291321f
+--- /dev/null
++++ b/data/surface-book3-15.tablet
+@@ -0,0 +1,14 @@
++# This is for the Microsoft Surface Book 3 15-inch model
++
++[Device]
++Name=Microsoft Surface Book 3 (15")
++Class=PenDisplay
++DeviceMatch=virt:045e:09b1;mei:045e:09b1
++Width=12
++Height=8
++IntegratedIn=Display;System;
++
++[Features]
++Stylus=false
++Touch=true
++Buttons=0
+-- 
+2.30.1
+

--- a/archlinuxcn/libwacom-surface/PKGBUILD
+++ b/archlinuxcn/libwacom-surface/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Maximilian Luz <luzmaximilian@gmail.com>
+# Based on official Arch Linux PKGBUILD
+
+pkgname=libwacom-surface
+pkgver=1.9
+pkgrel=1
+pkgdesc="Patched libwacom for Microsoft Surface devices"
+arch=('x86_64')
+url="https://github.com/linux-surface/libwacom"
+license=('MIT')
+depends=('glib2' 'systemd' 'libgudev')
+makedepends=('libxml2' 'meson')
+checkdepends=('python-pytest' 'python-libevdev' 'python-pyudev')
+validpgpkeys=('3C2C43D9447D5938EF4551EBE23B7E70B467F0BF')
+conflicts=('libwacom')
+provides=("libwacom=${pkgver}")
+
+source=(
+    '0001-Add-support-for-BUS_VIRTUAL.patch'
+    '0002-Add-support-for-Intel-Management-Engine-bus.patch'
+    '0003-data-Add-Microsoft-Surface-pro-4.patch'
+    '0004-data-Add-Microsoft-Surface-pro-5.patch'
+    '0005-data-Add-Microsoft-Surface-pro-6.patch'
+    '0006-data-Add-Microsoft-Surface-pro-7.patch'
+    '0007-data-Add-Microsoft-Surface-Book.patch'
+    '0008-data-Add-Microsoft-Surface-Book-2-13.5.patch'
+    '0009-data-Add-Microsoft-Surface-Book-2-15.patch'
+    '0010-data-Add-Microsoft-Surface-Book-3-13.5.patch'
+    '0011-data-Add-Microsoft-Surface-Book-3-15.patch'
+    "https://github.com/linuxwacom/libwacom/releases/download/libwacom-${pkgver}/libwacom-${pkgver}.tar.bz2"{,.sig}
+)
+sha256sums=('bee93db7423a1250f24172e5409166116568e47fe951569f178bfe5ce06129a6'
+            '6c41619a307cb1325997730fece7aacc0fce728b1c3f80244aa06289cf5611f3'
+            '136233738a219c4ee24b293bfdf73e8de2211c14ce6321a60018ad02b7c56c57'
+            '06a8b07b8446dc9d32bd0295e1b7c584f4d8e32840578366603e68b995bce6a7'
+            'af37d7ff44f201e6e7d2f90a8bea2fe1c162e9f1dab420b7e648d52a01549bb9'
+            '2cd478c179d42174c3e44c319bb8eb759c0b7a1dd6792523296cfe607e6e6270'
+            'f464d6f4911545b2fc776defadd231f07289e7aab64ac47e5337072701736cca'
+            'cefffa6d243215b71c5029db72921c12ac5cfce6f0232d6b1017f0002b8e65fd'
+            'a8c887074b89f3a2349c9dbe47f2e6a5bd6e4aa0675882f6486fcd0cec4a8243'
+            '6de413ca309288ef0daa4145db99cdc615ca5ac8b61250cf9ad336688a6bee97'
+            '37384fdd70039443d5d81b77a9bdb6dd00fb4c1143e90f3272fbca1096aee0b1'
+            '68b14d4e3b75fed9f590bf6eaea361a72dc23e933b7725094c779477acf665c7'
+            'SKIP')
+
+prepare() {
+    cd "libwacom-${pkgver}"
+
+    for p in "${srcdir}/"*.patch ; do
+        patch -Np1 -i "${p}" || true
+    done
+}
+
+build() {
+    meson build "libwacom-${pkgver}" --prefix="/usr"
+    ninja -C build
+}
+
+check() {
+    ninja test -C build
+}
+
+package() {
+    DESTDIR="${pkgdir}" ninja install -C build
+    install -D -m644 "libwacom-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/archlinuxcn/libwacom-surface/lilac.yaml
+++ b/archlinuxcn/libwacom-surface/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+    - github: SamLukeYes
+
+build_prefix: extra-x86_64
+
+pre_build_script: aur_pre_build(maintainers=['qzed'])
+
+post_build: aur_post_build
+
+update_on:
+    - source: aur
+      aur: libwacom-surface


### PR DESCRIPTION
`gnome-control-center-nocheese` is a patched version of `gnome-control-center` that doesn't depend on `cheese` -- you probably don't want to install `cheese` if you don't have a working camera.

`libwacom-surface` is a patched version of `libwacom` for Microsoft Surface devices: https://github.com/archlinuxcn/repo/issues/1961

This is my first pull request to archlinuxcn repo. Please correct me if I did something wrong :p