### PR TITLE
fix: harden aur_pre_build() of frantic1048's AUR packages

### DIFF
--- a/archlinuxcn/adguardhome/lilac.yaml
+++ b/archlinuxcn/adguardhome/lilac.yaml
@@ -3,7 +3,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['graysky'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/code-transparent/lilac.yaml
+++ b/archlinuxcn/code-transparent/lilac.yaml
@@ -3,7 +3,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['frantic1048'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/elvish/lilac.yaml
+++ b/archlinuxcn/elvish/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['hexchain', 'xiaq', 'farseerfc'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/flacon/lilac.yaml
+++ b/archlinuxcn/flacon/lilac.yaml
@@ -3,7 +3,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['ValHue'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/font-victor-mono/lilac.yaml
+++ b/archlinuxcn/font-victor-mono/lilac.yaml
@@ -3,7 +3,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['radmen'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/gitter/lilac.yaml
+++ b/archlinuxcn/gitter/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['ljmf00'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/kreogist-mu/lilac.yaml
+++ b/archlinuxcn/kreogist-mu/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['frantic1048'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/nvm/lilac.yaml
+++ b/archlinuxcn/nvm/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['tomwadley'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/pencil/lilac.yaml
+++ b/archlinuxcn/pencil/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['BrLi'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/plex-hama-bundle-git/lilac.yaml
+++ b/archlinuxcn/plex-hama-bundle-git/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: archlinuxcn-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['frantic1048', 'mka'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/plex-media-server/lilac.yaml
+++ b/archlinuxcn/plex-media-server/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: archlinuxcn-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['fryfrog'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/scrcpy/lilac.yaml
+++ b/archlinuxcn/scrcpy/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: archlinuxcn-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['nvllsvm'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/ttf-merriweather-sans/lilac.yaml
+++ b/archlinuxcn/ttf-merriweather-sans/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['CommodoreCrunch'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/ttf-merriweather/lilac.yaml
+++ b/archlinuxcn/ttf-merriweather/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['CommodoreCrunch'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/ttf-oswald/lilac.yaml
+++ b/archlinuxcn/ttf-oswald/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['CommodoreCrunch'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/ttf-quintessential/lilac.yaml
+++ b/archlinuxcn/ttf-quintessential/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['CommodoreCrunch'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/ttf-signika/lilac.yaml
+++ b/archlinuxcn/ttf-signika/lilac.yaml
@@ -5,7 +5,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['CommodoreCrunch'])
 
 post_build: aur_post_build
 


### PR DESCRIPTION
add explicit maintainers to aur_pre_build() calls.

affected packages:

- adguardhome
- code-transparent
- elvish
- flacon
- font-victor-mono
- gitter
- kreogist-mu
- nvm
- pencil
- plex-hama-bundle-git
- plex-media-server
- scrcpy
- ttf-merriweather-sans
- ttf-merriweather
- ttf-oswald
- ttf-quintessential
- ttf-signika

initiated by #2228