### PR TITLE
feat(vim-youcompleteme-git): using system clang

### DIFF
--- a/archlinuxcn/vim-youcompleteme-git/lilac.py
+++ b/archlinuxcn/vim-youcompleteme-git/lilac.py
@@ -5,3 +5,4 @@ from lilaclib import *
 def pre_build():
     aur_pre_build()
     run_cmd(['sh', '-c', 'sed \'/vim-plugins/d\' -i PKGBUILD'])
+    run_cmd(['sh', '-c', 'sed \'s/_use_system_clang="OFF"/_use_system_clang="ON"/\' -i PKGBUILD'])


### PR DESCRIPTION
The upstream (AUR) recently added the `using system clang` option
https://aur.archlinux.org/cgit/aur.git/commit/?h=vim-youcompleteme-git&id=88d59671e2511f8bda3a5e812fd5009c5a95511c
And it used system clang in the past, and the packages in the repo are also configured to use system clang (https://github.com/archlinuxcn/repo/blob/master/archlinuxcn/vim-youcompleteme-git/lilac.yaml#L14)

cc @dctxmei because it is maintained by he/she