### PR TITLE
Add NODE_ENV to ferdi-git startup script.

### DIFF
--- a/archlinuxcn/ferdi-git/ferdi.sh
+++ b/archlinuxcn/ferdi-git/ferdi.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec electron '/usr/lib/ferdi/app.asar' "$@"
+NODE_ENV=production exec electron '/usr/lib/ferdi/app.asar' "$@"


### PR DESCRIPTION
As of [this commit](https://github.com/getferdi/ferdi/commit/38de1e0cf41b9d5527d405952e2d66e983ca2a5c) it appears that ferdi requires the NODE_ENV environment variable now otherwise it will start up in dev mode. The AUR package for ferdi-git also has has NODE_ENV set for a long time so this should probably be added here.