### PR TITLE
fix: nerdctl 0.10.0 build command changed

### DIFF
--- a/archlinuxcn/nerdctl/PKGBUILD
+++ b/archlinuxcn/nerdctl/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Songmin Li <lisongmin@protonmail.com>
 pkgname=nerdctl
-pkgver=0.9.0
+pkgver=0.10.0
 pkgrel=1
 pkgdesc='Docker-compatible CLI for containerd.'
 makedepends=('go')
@@ -9,7 +9,7 @@ url='https://github.com/containerd/nerdctl'
 license=('Apache')
 provides=('nerdctl')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/containerd/${pkgname}/archive/v${pkgver}.tar.gz)
-sha256sums=('8324846d08e92a2153cdcb845940b37a33d5d1bcb6214da9d17d028ffec322f9')
+sha256sums=('d178881ef5c4ff61ac83869e388e3c968aa7b9075b0d33be21fe78e16c83affa')
 
 build() {
   export CGO_CPPFLAGS="${CPPFLAGS}"
@@ -24,7 +24,7 @@ build() {
   sed -i 's/^\(.*Version =\) ".*"$/\1 "'${pkgver}'"/g' pkg/version/version.go
   sed -i 's/^\(.*Revision =\) ".*"$/\1 "'${pkgrel}'"/g' pkg/version/version.go
 
-  go build -o nerdctl
+  go build -o nerdctl github.com/containerd/nerdctl/cmd/nerdctl
 
   ./nerdctl completion bash > nerdctl.bash
 }


### PR DESCRIPTION

修正 升级到 nerdctl 0.10 后，不能编译的问题。

https://github.com/containerd/nerdctl/releases/tag/v0.10.0

```
The Go package github.com/containerd/nerdctl was moved to github.com/containerd/nerdctl/cmd/nerdctl (#269)

    Users using go install github.com/containerd/nerdctl will need to change their installation script to go install github.com/containerd/nerdctl/cmd/nerdctl
    Users using make or the binary distribution are unaffected
```