### PR TITLE
fix(telegram-desktop-git): Fix missing jemalloc runtime depends

### DIFF
--- a/archlinuxcn/telegram-desktop-git/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-git/PKGBUILD
@@ -9,7 +9,7 @@ url="https://desktop.telegram.org/"
 license=('GPL3')
 depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal' 'ttf-opensans'
          'qt5-imageformats' 'xxhash' 'libdbusmenu-qt5' 'kwayland' 'gtk3' 'glibmm'
-         'webkit2gtk' 'rnnoise' 'pipewire' 'libxtst' 'libxrandr' )
+         'webkit2gtk' 'rnnoise' 'pipewire' 'libxtst' 'libxrandr' 'jemalloc')
 makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'microsoft-gsl'
              'extra-cmake-modules' 'jemalloc'
              'libtg_owt-git')


### PR DESCRIPTION
After upgrade telegram-desktop-git, it crash after start.
```
$ telegram-desktop 
telegram-desktop: error while loading shared libraries: libjemalloc.so.2: cannot open shared object file: No such file or directory
```

It can working properly after install [extra/jemalloc](https://archlinux.org/packages/extra/x86_64/jemalloc/)

![](https://user-images.githubusercontent.com/46131041/126101193-2fd39855-ca51-4a61-ab28-635d619125d7.png)
