### PR TITLE
telegram-desktop-megumifox: sync with upstream

### DIFF
--- a/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
@@ -10,9 +10,11 @@ arch=('x86_64')
 url="https://desktop.telegram.org/"
 license=('GPL3')
 depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal'
-         'qt5-imageformats' 'xxhash' 'libdbusmenu-qt5' 'kwayland' 'libx11' 'glibmm' 'rnnoise' 'pipewire' 'libxtst' 'libxrandr' 'jemalloc')
-makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'python2' 'microsoft-gsl' 'libtg_owt' 'extra-cmake-modules')
-optdepends=('ttf-opensans: default Open Sans font family')
+         'qt5-imageformats' 'xxhash' 'libdbusmenu-qt5' 'kwayland' 'libx11' 'glibmm'
+         'rnnoise' 'pipewire' 'libxtst' 'libxrandr' 'jemalloc' 'libtg_owt')
+makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'python2' 'microsoft-gsl' 'extra-cmake-modules')
+optdepends=('ttf-opensans: default Open Sans font family'
+            'xdg-desktop-portal: desktop integration')
 provides=('telegram-desktop')
 conflicts=('telegram-desktop')
 source=("https://github.com/telegramdesktop/tdesktop/releases/download/v${pkgver}/tdesktop-${pkgver}-full.tar.gz"
@@ -28,12 +30,6 @@ prepare() {
     patch -b -d tdesktop-$pkgver-full/Telegram/lib_ui/ -Np1 -i ${srcdir}/0001-use-system-font-and-use-stylename.patch
     patch -b -d tdesktop-$pkgver-full/ -Np1 -i ${srcdir}/0002-fix-webrtc-integration-build-missing-libx11.patch
     patch -b -l -d tdesktop-$pkgver-full/ -Np1 -i ${srcdir}/0003-add-TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME-back.patch
-    # force webrtc link to libjpeg and X11 libs
-    cd tdesktop-$pkgver-full/cmake
-    echo "target_link_libraries(external_webrtc INTERFACE jpeg)" | tee -a external/webrtc/CMakeLists.txt
-    echo "find_package(X11 REQUIRED COMPONENTS Xcomposite Xdamage Xext Xfixes Xrender Xrandr Xtst)" | tee -a external/webrtc/CMakeLists.txt
-    echo "target_link_libraries(external_webrtc INTERFACE Xcomposite Xdamage Xext Xfixes Xrandr Xrender Xtst)" | tee -a external/webrtc/CMakeLists.txt
-
 }
 
 build() {
@@ -42,7 +38,7 @@ build() {
     # Turns out we're allowed to use the official API key that telegram uses for their snap builds:
     # https://github.com/telegramdesktop/tdesktop/blob/8fab9167beb2407c1153930ed03a4badd0c2b59f/snap/snapcraft.yaml#L87-L88
     # Thanks @primeos!
-    cmake . \
+    cmake \
         -B build \
         -G Ninja \
         -DCMAKE_INSTALL_PREFIX="/usr" \
@@ -50,12 +46,10 @@ build() {
         -DTDESKTOP_API_ID=611335 \
         -DTDESKTOP_API_HASH=d524b414d21f4d37f08684c1df41ac9c \
         -DTDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME=ON \
-        -DTDESKTOP_LAUNCHER_BASENAME="telegramdesktop" \
-        -DDESKTOP_APP_SPECIAL_TARGET="" \
         -DDESKTOP_APP_USE_PACKAGED_LAZY=OFF \
         -DDESKTOP_APP_USE_PACKAGED_FONTS=OFF \
-    	-DDESKTOP_APP_DISABLE_GTK_INTEGRATION=ON \
-	-DDESKTOP_APP_DISABLE_WEBKITGTK=ON
+        -DDESKTOP_APP_DISABLE_GTK_INTEGRATION=ON \
+        -DDESKTOP_APP_DISABLE_WEBKITGTK=ON
     ninja -C build
 }
 


### PR DESCRIPTION
add missing runtime dependency `libtg_owt`