### PR TITLE
wine-wechat: there is no XDG_DATA_DIR

### DIFF
--- a/archlinuxcn/wine-wechat/wechat
+++ b/archlinuxcn/wine-wechat/wechat
@@ -47,7 +47,7 @@ if __name__ == '__main__':
                       help='arguments for WeChat.exe')
   args = parser.parse_args()
 
-  root = os.environ.get('XDG_DATA_DIR', os.environ['HOME'] + '/.local')
+  root = os.environ['HOME'] + '/.local'
   root = pathlib.Path(root)
   prefix = root / 'lib/wine-wechat' / (args.profile or 'default')
   tarball = pathlib.Path('/opt/wine-wechat/wine-wechat.tar.zst')


### PR DESCRIPTION
According to [the spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), there is only `XDG_DATA_DIRS`, instead of `XDG_DATA_DIR`. In this case, it should be okay to just use `~/.local` as said by [`file-hierarchy`](https://www.freedesktop.org/software/systemd/man/file-hierarchy.html#Home%20Directory).