### PR TITLE
grub-themes-git: fix info.png missing issue

### DIFF
--- a/archlinuxcn/grub-themes-git/PKGBUILD
+++ b/archlinuxcn/grub-themes-git/PKGBUILD
@@ -66,7 +66,7 @@ pkgname=('grub-theme-tela-color-1080p-git'
          'grub-theme-whitesur-whitesur-2k-git'
          'grub-theme-whitesur-whitesur-4k-git')
 pkgver=2021.01.26.r28.g2b42974
-pkgrel=1
+pkgrel=2
 pkgdesc="Flat Design themes for Grub"
 arch=('any')
 url="https://github.com/vinceliuice/grub2-themes"

--- a/archlinuxcn/grub-themes-git/PKGBUILD
+++ b/archlinuxcn/grub-themes-git/PKGBUILD
@@ -92,12 +92,15 @@ _package() {
             if [[ "${resolution}" == 'ultrawide' ]]; then
                 install -Dm 644 assets/assets-select/select-1080p/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/
                 install -Dm 644 assets/"assets-${icon}"/icons-1080p/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/icons/
+                install -Dm 644 assets/info-1080p.png "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/info.png
             elif [[ "${resolution}" == 'ultrawide2k' ]]; then
                 install -Dm 644 assets/assets-select/select-2k/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/
                 install -Dm 644 assets/"assets-${icon}"/icons-2k/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/icons/
+                install -Dm 644 assets/info-2k.png "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/info.png
             else
                 install -Dm 644 assets/assets-select/"select-${resolution}"/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/
                 install -Dm 644 assets/"assets-${icon}"/"icons-${resolution}"/* -t "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/icons/
+                install -Dm 644 assets/"info-${resolution}.png" "${pkgdir}"/usr/share/grub/themes/"${name}-${icon}-${resolution}"/info.png
             fi
         fi
     done


### PR DESCRIPTION
虽然已经有了 <https://github.com/archlinuxcn/repo/pull/2479>，然而其提供的 PKGBUILD 并不能编译。

Fix #2482