### PR TITLE
kdiskmark-git: conflicts with kdiskmark

### DIFF
--- a/archlinuxcn/kdiskmark-git/PKGBUILD
+++ b/archlinuxcn/kdiskmark-git/PKGBUILD
@@ -11,7 +11,7 @@ license=('GPL3')
 depends=('fio' 'hicolor-icon-theme' 'qt5-base' 'kauth')
 makedepends=('extra-cmake-modules' 'git' 'qt5-tools')
 provides=("${_pkgname,,}")
-conflicts=("kdiskmark")
+conflicts=("${_pkgname,,}")
 source=("${_pkgname}::git+${url}.git")
 sha256sums=('SKIP')
 

--- a/archlinuxcn/kdiskmark-git/PKGBUILD
+++ b/archlinuxcn/kdiskmark-git/PKGBUILD
@@ -11,6 +11,7 @@ license=('GPL3')
 depends=('fio' 'hicolor-icon-theme' 'qt5-base' 'kauth')
 makedepends=('extra-cmake-modules' 'git' 'qt5-tools')
 provides=("${_pkgname,,}")
+conflicts=("kdiskmark")
 source=("${_pkgname}::git+${url}.git")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
```bash
❯ sudo pacman -Syu kdiskmark-git
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
 multilib is up to date
 archlinuxcn                                                  1942.4 KiB   719 KiB/s 00:03 [-----------------------------------------------------] 100%
:: Starting full system upgrade...
resolving dependencies...
looking for conflicting packages...

Package (1)                New Version          Net Change  Download Size

archlinuxcn/kdiskmark-git  2.3.0.r2.g9952d5f-1    0.39 MiB       0.14 MiB

Total Download Size:   0.14 MiB
Total Installed Size:  0.39 MiB

:: Proceed with installation? [Y/n] 
:: Retrieving packages...
 kdiskmark-git-2.3.0.r2.g9952d5f-1-x86_64                      138.3 KiB   207 KiB/s 00:01 [-----------------------------------------------------] 100%
(1/1) checking keys in keyring                                                             [-----------------------------------------------------] 100%
(1/1) checking package integrity                                                           [-----------------------------------------------------] 100%
(1/1) loading package files                                                                [-----------------------------------------------------] 100%
(1/1) checking for file conflicts                                                          [-----------------------------------------------------] 100%
error: failed to commit transaction (conflicting files)
kdiskmark-git: /usr/bin/kdiskmark exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/lib/kauth/kdiskmark_helper exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/applications/kdiskmark.desktop exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/dbus-1/system-services/org.jonmagon.kdiskmark.service exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/dbus-1/system.d/org.jonmagon.kdiskmark.conf exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/128x128/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/16x16/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/24x24/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/256x256/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/32x32/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/48x48/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/512x512/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/icons/hicolor/64x64/apps/kdiskmark.png exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_cs_CZ.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_de_DE.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_es_MX.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_fr_FR.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_hi_IN.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_it_IT.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_pl_PL.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_pt_BR.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_ru_RU.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_sk_SK.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_uk_UA.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/kdiskmark/translations/kdiskmark_zh_CN.qm exists in filesystem (owned by kdiskmark)
kdiskmark-git: /usr/share/polkit-1/actions/org.jonmagon.kdiskmark.policy exists in filesystem (owned by kdiskmark)
Errors occurred, no packages were upgraded.
```