### PR TITLE
bear: rebuild on grpc and protobuf

### DIFF
--- a/archlinuxcn/bear/lilac.yaml
+++ b/archlinuxcn/bear/lilac.yaml
@@ -13,3 +13,5 @@ post_build: aur_post_build
 update_on:
   - source: aur
     aur: bear
+  - alias: grpc
+  - alias: protobuf


### PR DESCRIPTION
after grpc upgrade:
```
/usr/bin/intercept: error while loading shared libraries: libgrpc++.so.1.41: cannot open shared object file: No such file or directory
```

```
➜ ldd /usr/bin/intercept
        linux-vdso.so.1 (0x00007ffeb459c000)
        libprotobuf.so.28 => /usr/lib/libprotobuf.so.28 (0x00007f98248fb000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f98248da000)
        libgrpc++.so.1.41 => not found
        libabsl_synchronization.so.2103.0.1 => not found
        libspdlog.so.1 => /usr/lib/libspdlog.so.1 (0x00007f982485d000)
        libfmt.so.8 => /usr/lib/libfmt.so.8 (0x00007f982483a000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f9824831000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f982461b000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f9824600000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f9824434000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007f982441a000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f98242d6000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f9824cfa000)
```