### PR TITLE
python-onnx: fix Python 3.10 compatibility

### DIFF
--- a/archlinuxcn/python-onnx/PKGBUILD
+++ b/archlinuxcn/python-onnx/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=python-onnx
 pkgver=1.10.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Open Neural Network Exchange'
 arch=('x86_64')
 url='https://onnx.ai'
@@ -26,6 +26,8 @@ sha512sums=('SKIP')
 prepare() {
   cd "${pkgname}"
   git submodule update --init --recursive
+  # Partial backpart from https://github.com/onnx/onnx/pull/3674
+  sed -i 's#collections.Iterable#collections.abc.Iterable#g' onnx/helper.py
 }
 
 build() {


### PR DESCRIPTION
See: https://github.com/onnx/onnx/pull/3674

The partially-broken package was successfully built as tests are removed (108f7568f21c9c4d16cd3c16bc6059ae6957ae93).

Well, maybe I shouldn't tell people to remove tests (https://github.com/archlinuxcn/repo/issues/2564) instead of fixing them.