### PR TITLE
addpkg: xrock-git

### DIFF
--- a/archlinuxcn/xrock-git/PKGBUILD
+++ b/archlinuxcn/xrock-git/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: taotieren <admin@taotieren.com>
+
+pkgname=xrock-git
+pkgver=1.0.2.r4.g5458355
+pkgrel=1
+epoch=
+pkgdesc="The low level tools for rockchip SOC with maskrom and loader mode support."
+arch=('any')
+url="https://github.com/xboot/xrock"
+license=('MIT')
+groups=()
+depends=('libusb')
+makedepends=("gcc")
+checkdepends=()
+optdepends=()
+provides=()
+conflicts=(${pkgname%-git})
+replaces=()
+backup=()
+options=('!strip')
+install=
+changelog=
+source=("${pkgname%-git}::git+https://ghproxy.com/${url}.git")
+noextract=()
+sha256sums=('SKIP')
+#validpgpkeys=()
+
+pkgver() {
+    cd "${srcdir}/${pkgname%-git}"
+    git describe --long --tags | sed 's/^v//g' | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+    cd "${srcdir}/${pkgname%-git}"
+    make
+}
+
+package() {
+    install -Dm0755 "${srcdir}/${pkgname%-git}/${pkgname%-git}" "${pkgdir}/usr/bin/${pkgname%-git}"
+    install -Dm0644 "${srcdir}/${pkgname%-git}/99-xrock.rules" "${pkgdir}/etc/udev/rules.d/99-xrock.rules"
+    install -Dm0644 "${srcdir}/${pkgname%-git}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname%-git}/LICENSE"
+}

--- a/archlinuxcn/xrock-git/lilac.yaml
+++ b/archlinuxcn/xrock-git/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: taotieren
+
+build_prefix: extra-x86_64
+
+pre_build: vcs_update
+
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    gitlab: xboot/xrock


### PR DESCRIPTION
The low level tools for rockchip SOC with maskrom and loader mode support.
```bash
usage:
    xrock maskrom <ddr> <usbplug> [--rc4-off] - Initial chip using ddr and usbplug in maskrom mode
    xrock version                             - Show chip version
    xrock capability                          - Show capability information
    xrock reset [maskrom]                     - Reset chip to normal or maskrom mode
    xrock hexdump <address> <length>          - Dumps memory region in hex
    xrock dump <address> <length>             - Binary memory dump to stdout
    xrock read <address> <length> <file>      - Read memory to file
    xrock write <address> <file>              - Write file to memory
    xrock exec <address>                      - Call function address
    xrock flash                               - Detect flash and show information
    xrock flash erase <sector> <count>        - Erase flash sector
    xrock flash read <sector> <count> <file>  - Read flash sector to file
    xrock flash write <sector> <file>         - Write file to flash sector
```