### PR TITLE
fix: remove `npm --user root`

### DIFF
--- a/archlinuxcn/babel-eslint/PKGBUILD
+++ b/archlinuxcn/babel-eslint/PKGBUILD
@@ -12,7 +12,8 @@ noextract=("$pkgname-$pkgver.tgz")
 sha512sums=('89f59a4c743471efb8e3c098a29f0076b42206c1ab9c2f9b3207f2285762e84b0f2d30161be41fc8378ce8e1fe1665a72af12ae4d9c130bbe50543ca419a034a')
 
 package() {
-  npm install -g --user root --prefix "$pkgdir"/usr "$srcdir"/$pkgname-$pkgver.tgz
+  npm install -g --prefix "$pkgdir"/usr "$srcdir"/$pkgname-$pkgver.tgz
+  chown -R root:root "$pkgdir"
 
   # Fix permissions
   find "$pkgdir/usr" -type d -exec chmod 755 '{}' +

--- a/archlinuxcn/joplin/PKGBUILD
+++ b/archlinuxcn/joplin/PKGBUILD
@@ -100,7 +100,7 @@ package_joplin() {
   local pack="$(npm pack | tail -n 1)"
 
   msg2 "Installing CLI ($pack)"
-  npm install --global --production --cache "$cache" \
+  npm install --global --production --user root --cache "$cache" \
     --prefix "${pkgdir}/tmp" "$pack"
 
   msg2 "Rearranging directory tree"

--- a/archlinuxcn/joplin/PKGBUILD
+++ b/archlinuxcn/joplin/PKGBUILD
@@ -100,7 +100,7 @@ package_joplin() {
   local pack="$(npm pack | tail -n 1)"
 
   msg2 "Installing CLI ($pack)"
-  npm install --global --production --user root --cache "$cache" \
+  npm install --global --production --cache "$cache" \
     --prefix "${pkgdir}/tmp" "$pack"
 
   msg2 "Rearranging directory tree"

--- a/archlinuxcn/pnpm/PKGBUILD
+++ b/archlinuxcn/pnpm/PKGBUILD
@@ -13,7 +13,7 @@ noextract=("$pkgname-$pkgver.tgz")
 sha256sums=('3c43a6dce8ed04f77b234338fdfbaad993f0adb22c41ab78dd81bba8e0ea88d2')
 
 package() {
-  npm install -g --user root --prefix "$pkgdir"/usr "$srcdir/$pkgname-$pkgver.tgz"
+  npm install -g --prefix "$pkgdir"/usr "$srcdir/$pkgname-$pkgver.tgz"
 
   find "$pkgdir"/usr -type d -exec chmod 755 {} +
   chown -R root:root "$pkgdir"


### PR DESCRIPTION
Since npm 7, the `--user` option is no longer available. `--user root` not only doesn't fix the permission problem, but also installs the package called "root", which conflicts with other packages that also have the `--user root` option.