### PR TITLE
telegram-desktop-megumifox: allow reading font family name from env

### DIFF
--- a/archlinuxcn/telegram-desktop-megumifox/0001-Use-QGuiApplication-font-instead-of-opensans.patch
+++ b/archlinuxcn/telegram-desktop-megumifox/0001-Use-QGuiApplication-font-instead-of-opensans.patch
@@ -1,27 +1,21 @@
-From 7e9ccc1b68d9e348930860a8ae285e743e33e600 Mon Sep 17 00:00:00 2001
-From: Megumi_fox <i@megumifox.com>
-Date: Sun, 9 Jan 2022 20:31:07 +0800
-Subject: [PATCH] Use QGuiApplication::font() instead of opensans
-
----
- ui/style/style_core_custom_font.cpp | 30 +++--------------------------
- 1 file changed, 3 insertions(+), 27 deletions(-)
-
 diff --git a/ui/style/style_core_custom_font.cpp b/ui/style/style_core_custom_font.cpp
-index 825726f..bcd7ceb 100644
+index 825726f1af..8525c701c0 100644
 --- a/ui/style/style_core_custom_font.cpp
 +++ b/ui/style/style_core_custom_font.cpp
-@@ -30,40 +30,16 @@ QFont ResolveFont(uint32 flags, int size) {
+@@ -30,40 +30,18 @@ QFont ResolveFont(uint32 flags, int size) {
  	static auto Database = QFontDatabase();
  
  	const auto bold = ((flags & FontBold) || (flags & FontSemibold));
 -	const auto italic = (flags & FontItalic);
 -	const auto &custom = bold ? BoldFont : RegularFont;
 -	const auto useCustom = !custom.family.isEmpty();
++   const QString FontFamilyName = qEnvironmentVariable("TELEGRAM_DESKTOP_UI_FONT");
++   const QString FontFamilyNameMono = qEnvironmentVariable("TELEGRAM_DESKTOP_UI_FONT_MONO");
  
- 	auto result = QFont(QGuiApplication::font().family());
+-	auto result = QFont(QGuiApplication::font().family());
++	auto result = QFont(FontFamilyName.isEmpty() ? QGuiApplication::font().family() : FontFamilyName);
  	if (flags & FontMonospace) {
- 		result.setFamily(MonospaceFont());
+-		result.setFamily(MonospaceFont());
 -	} else if (useCustom) {
 -		const auto sizes = Database.smoothSizes(custom.family, custom.style);
 -		const auto good = sizes.isEmpty()
@@ -44,17 +38,15 @@ index 825726f..bcd7ceb 100644
 -				result.setStyleName("Semibold");
 -			}
 -		}
++       result.setFamily(FontFamilyNameMono.isEmpty() ? MonospaceFont() : FontFamilyNameMono);
  	}
 -	if (italic) {
 -		result.setItalic(true);
 +	if (bold) {
-+			result.setWeight(QFont::Medium);
++           result.setWeight(QFont::Medium);
  	}
  
 +	result.setItalic(flags & FontItalic);
  	result.setUnderline(flags & FontUnderline);
  	result.setStrikeOut(flags & FontStrikeOut);
  	result.setPixelSize(size);
--- 
-2.34.1
-

--- a/archlinuxcn/telegram-desktop-megumifox/0001-Use-QGuiApplication-font-instead-of-opensans.patch
+++ b/archlinuxcn/telegram-desktop-megumifox/0001-Use-QGuiApplication-font-instead-of-opensans.patch
@@ -2,7 +2,7 @@ diff --git a/ui/style/style_core_custom_font.cpp b/ui/style/style_core_custom_fo
 index 825726f1af..8525c701c0 100644
 --- a/ui/style/style_core_custom_font.cpp
 +++ b/ui/style/style_core_custom_font.cpp
-@@ -30,40 +30,18 @@ QFont ResolveFont(uint32 flags, int size) {
+@@ -30,40 +30,23 @@ QFont ResolveFont(uint32 flags, int size) {
  	static auto Database = QFontDatabase();
  
  	const auto bold = ((flags & FontBold) || (flags & FontSemibold));
@@ -11,6 +11,7 @@ index 825726f1af..8525c701c0 100644
 -	const auto useCustom = !custom.family.isEmpty();
 +   const QString FontFamilyName = qEnvironmentVariable("TELEGRAM_DESKTOP_UI_FONT");
 +   const QString FontFamilyNameMono = qEnvironmentVariable("TELEGRAM_DESKTOP_UI_FONT_MONO");
++   const QString FontFamilyBoldStyle = qEnvironmentVariable("TELEGRAM_DESKTOP_UI_FONT_BOLD_STYLE");
  
 -	auto result = QFont(QGuiApplication::font().family());
 +	auto result = QFont(FontFamilyName.isEmpty() ? QGuiApplication::font().family() : FontFamilyName);
@@ -43,7 +44,11 @@ index 825726f1af..8525c701c0 100644
 -	if (italic) {
 -		result.setItalic(true);
 +	if (bold) {
-+           result.setWeight(QFont::Medium);
++           if (FontFamilyBoldStyle.isEmpty()){
++               result.setWeight(QFont::Medium);
++           }else{
++               result.setStyleName(FontFamilyBoldStyle);
++           }
  	}
  
 +	result.setItalic(flags & FontItalic);

--- a/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: hexchain <i@hexchain.org>
 pkgname=telegram-desktop-megumifox
 _pkgname=telegram-desktop
-pkgver=3.5.0
+pkgver=3.5.1
 pkgrel=2
 pkgdesc='Official Telegram Desktop client with megumifox patch'
 arch=('x86_64')
@@ -21,8 +21,8 @@ conflicts=('telegram-desktop')
 source=("https://github.com/telegramdesktop/tdesktop/releases/download/v${pkgver}/tdesktop-${pkgver}-full.tar.gz"
         "0001-Use-QGuiApplication-font-instead-of-opensans.patch"
         "0002-add-TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME-back.patch")
-sha512sums=('5a86f8e3dd1b7fca2a615a2de86f9640f14bbf27b7e73f735dad60629ddb99bd5c951d7311f99c044ab6178a49ff997aae5e8da0f8bb6753fa7eecfb12562cef'
-            'a037b64ccbb52757ab1834c351641b8d4868a2b84dd17a803f29989698dfa4bbb67bba39022806145a0b1a12d172ca1a5f12c00051c06dcc0463b5198303c63a'
+sha512sums=('7b8996afc6aeba544bcd46a25dea0ea6ca0b4ef934ae4b2e8fb2717597f7d67769ddce37ba6c3e4c89bdba269bb406a18d60504dd7742a6e4d45f6e6f8a88ab8'
+            'cc48d9116a918df5479c4508e9b98536772cafd9bc736ca40fdbedc3ea8ee0188eb0434046177ef49e0a124668e8c707433af90b11879ef0cf43911ab67a56cb'
             '7a1dcfc563b764d1e68acb566df52890ad527ba2c442ac78825239bce64da3d77ca5f7cf965c67dafc5290e3549fa52780fc49b2d991cd798d05735a6143f46b')
 
 prepare() {

--- a/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: hexchain <i@hexchain.org>
 pkgname=telegram-desktop-megumifox
 _pkgname=telegram-desktop
-pkgver=3.5.1
-pkgrel=1
+pkgver=3.5.0
+pkgrel=2
 pkgdesc='Official Telegram Desktop client with megumifox patch'
 arch=('x86_64')
 url="https://desktop.telegram.org/"
@@ -21,8 +21,8 @@ conflicts=('telegram-desktop')
 source=("https://github.com/telegramdesktop/tdesktop/releases/download/v${pkgver}/tdesktop-${pkgver}-full.tar.gz"
         "0001-Use-QGuiApplication-font-instead-of-opensans.patch"
         "0002-add-TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME-back.patch")
-sha512sums=('7b8996afc6aeba544bcd46a25dea0ea6ca0b4ef934ae4b2e8fb2717597f7d67769ddce37ba6c3e4c89bdba269bb406a18d60504dd7742a6e4d45f6e6f8a88ab8'
-            '3eb297f504f182cd62724bd6a21ef01bf14e440240e170222d766ae952f1428630c27e8d651f0d33fc0930b3d083e4e3e34e3b5bc355e992b426959e59dcbc55'
+sha512sums=('5a86f8e3dd1b7fca2a615a2de86f9640f14bbf27b7e73f735dad60629ddb99bd5c951d7311f99c044ab6178a49ff997aae5e8da0f8bb6753fa7eecfb12562cef'
+            'a037b64ccbb52757ab1834c351641b8d4868a2b84dd17a803f29989698dfa4bbb67bba39022806145a0b1a12d172ca1a5f12c00051c06dcc0463b5198303c63a'
             '7a1dcfc563b764d1e68acb566df52890ad527ba2c442ac78825239bce64da3d77ca5f7cf965c67dafc5290e3549fa52780fc49b2d991cd798d05735a6143f46b')
 
 prepare() {

--- a/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
+++ b/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
@@ -8,3 +8,5 @@ update_on:
     github: telegramdesktop/tdesktop
     branch: dev
     use_latest_release: true
+  - source: manual
+    manual: 1

--- a/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
+++ b/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
@@ -9,4 +9,4 @@ update_on:
     branch: dev
     use_latest_release: true
   - source: manual
-    manual: 1
+    manual: 2


### PR DESCRIPTION
allows the user to specify custom UI font family name by two environment variables:
TELEGRAM_DESKTOP_UI_FONT and TELEGRAM_DESKTOP_UI_FONT_MONO