### PR TITLE
尊敬的管理员您好，我对optimus-manager进行了些许更改

### DIFF
--- a/archlinuxcn/optimus-manager/optimus-manager.conf
+++ b/archlinuxcn/optimus-manager/optimus-manager.conf
@@ -1,0 +1,154 @@
+[optimus]
+
+# This parameter defines the method used to power switch the Nvidia card. See the documentation
+# for a complete description of what each value does. Possible values :
+#
+# - nouveau : load the nouveau module on the Nvidia card.
+# - bbswitch : power off the card using the bbswitch module (requires the bbswitch dependency).
+# - acpi_call : try various ACPI method calls to power the card on and off (requires the acpi_call dependency)
+# - custom: use custom scripts at /etc/optimus-manager/nvidia-enable.sh and /etc/optimus-manager/nvidia-disable.sh
+# - none : do not use an external module for power management. For some laptop models it's preferable to
+#          use this option in combination with pci_power_control (see below).
+switching=none
+
+# Enable PCI power management in "integrated" mode.
+# This option is incompatible with acpi_call and bbswitch, so it will be ignored in those cases.
+pci_power_control=no
+
+# Remove the Nvidia card from the PCI bus.
+# May prevent crashes caused by power switching.
+# Ignored if switching=nouveau or switching=bbswitch.
+pci_remove=no
+
+# Reset the Nvidia card at the PCI level before reloading the nvidia module.
+# Ensures the card is in a fresh state before reloading the nvidia module.
+# May fix some switching issues. Possible values :
+#
+# - no : does not perform any reset
+# - function_level : perform a light "function-level" reset
+# - hot_reset : perform a "hot reset" of the PCI bridge. ATTENTION : this method messes with the hardware
+#         directly, please read the online documentation of optimus-manager before using it.
+#         Also, it will perform a PCI remove even if pci_remove=no.
+#
+pci_reset=no
+
+# Automatically log out the current desktop session when switching GPUs.
+# This feature is currently supported for the following DE/WM :
+# GNOME, KDE Plasma, LXDE, Deepin, Xfce, i3, Openbox, AwesomeWM, bspwm and dwm
+# If this option is disabled or you use a different desktop environment,
+# GPU switching only becomes effective at the next graphical session login.
+auto_logout=yes
+
+# GPU mode to use at computer startup.
+# Possible values: nvidia, integrated, hybrid, auto, intel (deprecated, equivalent to integrated)
+# "auto" is a special mode that auto-detects if the computer is running on battery
+# and selects a proper GPU mode. See the other options below.
+startup_mode=integrated
+# GPU mode to select when startup_mode=auto and the computer is running on battery.
+# Possible values: nvidia, integrated, hybrid, intel (deprecated, equivalent to integrated)
+startup_auto_battery_mode=integrated
+# GPU mode to select when startup_mode=auto and the computer is running on external power.
+# Possible values: nvidia, integrated, hybrid, intel (deprecated, equivalent to integrated)
+startup_auto_extpower_mode=nvidia
+
+
+[intel]
+
+# Driver to use for the Intel GPU. Possible values : modesetting, intel
+# To use the intel driver, you need to install the package "xf86-video-intel".
+driver=modesetting
+
+# Acceleration method (corresponds to AccelMethod in the Xorg configuration).
+# Only applies to the intel driver.
+# Possible values : sna, xna, uxa
+# Leave blank for the default (no option specified)
+accel=
+
+# Enable TearFree option in the Xorg configuration.
+# Only applies to the intel driver.
+# Possible values : yes, no
+# Leave blank for the default (no option specified)
+tearfree=
+
+# DRI version. Possible values : 2, 3
+DRI=3
+
+# Whether or not to enable modesetting for the nouveau driver.
+# Does not affect modesetting for the Intel GPU driver !
+# This option only matters if you use nouveau as the switching backend.
+modeset=yes
+
+
+[amd]
+
+# Driver to use for the AMD GPU. Possible values : modesetting, amdgpu
+# To use the amdgpu driver, you need to install the package "xf86-video-amdgpu".
+driver=modesetting
+
+# Enable TearFree option in the Xorg configuration.
+# Only applies to the amdgpu driver.
+# Possible values : yes, no
+# Leave blank for the default (no option specified)
+tearfree=
+
+# DRI version. Possible values : 2, 3
+DRI=3
+
+
+[nvidia]
+
+# Whether or not to enable modesetting. Required for PRIME ynchronization (which prevents tearing).
+modeset=yes
+
+# Whether or not to enable the NVreg_UsePageAttributeTable option in the Nvidia driver.
+# Recommended, can cause poor CPU performance otherwise.
+PAT=yes
+
+# DPI value. This will be set using the Xsetup script passed to your login manager.
+# It will run the command
+# xrandr --dpi <DPI>
+# Leave blank for the default (the above command will not be run).
+DPI=96
+
+# If you're running an updated version of xorg-server (let's say to get PRIME Render offload enabled),
+# the nvidia driver may not load because of an ABI version mismatch. Setting this flag to "yes"
+# will allow the loading of the nvidia driver.
+ignore_abi=no
+
+# Set to yes if you want to use optimus-manager with external Nvidia GPUs (experimental)
+allow_external_gpus=no
+
+# Comma-separated list of Nvidia-specific options to apply.
+# Available options :
+# - overclocking : enable CoolBits in the Xorg configuration, which unlocks clocking options
+#   in the Nvidia control panel. Note: does not work in hybrid mode.
+# - triple_buffer : enable triple buffering.
+options=overclocking
+
+
+# Enable Runtime D3 (RTD3) Power Management in the Nvidia driver. While in hybrid mode,
+# this feature allows the Nvidia card to go into a low-power mode if it's not in use.
+#
+# IMPORTANT NOTES:
+# - The feature is still experimental
+# - It's only supported on laptops with a Turing GPU or above, and an Intel Coffee Lake CPU
+# or above (not sure about the state of support for AMD CPUs).
+# - if your Nvidia card also has an audio chip (for HDMI) or a USB port wired to it, they may not
+# function properly while in low-power mode
+#
+# For more details, see
+# https://download.nvidia.com/XFree86/Linux-x86_64/460.39/README/dynamicpowermanagement.html
+#
+# Available options:
+# - no (the default): RTD3 power management is disabled.
+# - coarse: the card only goes to low-power if no application is using it.
+# - fine: the card is also allowed to go to low-power if applications are using it but have not
+# actively submitted GPU work in some amount of time.
+dynamic_power_management=no
+
+# The Nvidia driver handles power to the video memory separately from the rest of GPU.
+# When dynamic_power_management=fine, this options controls the threshold of memory utilization
+# (in Megabytes) under which the memory is put in a low-power state.
+# Values over 200MB are ignored. Leave blank for the default (200MB).
+# Setting this value to 0 keeps the memory powered at all times.
+dynamic_power_management_memory_threshold=S

--- a/archlinuxcn/optimus-manager/optimus-manager.install
+++ b/archlinuxcn/optimus-manager/optimus-manager.install
@@ -10,6 +10,8 @@ post_install() {
     red=$(tput setaf 1)
     normal=$(tput sgr0)
     echo "${bold}${red}Please reboot your computer before using optimus-manager${normal}"
+	echo "Start create optimus-manager.conf in /etc/optimus-manager"
+	cp optimus-manager.conf /etc/optimus-manager
 }
 
 post_remove() {

--- a/archlinuxcn/optimus-manager/optimus-manager.install
+++ b/archlinuxcn/optimus-manager/optimus-manager.install
@@ -12,6 +12,7 @@ post_install() {
     echo "${bold}${red}Please reboot your computer before using optimus-manager${normal}"
 	echo "Start create optimus-manager.conf in /etc/optimus-manager"
 	cp optimus-manager.conf /etc/optimus-manager
+	echo "Finish created in /etc/optimus-manager, and if you can know more on https://github.com/Askannz/optimus-manager"
 }
 
 post_remove() {
@@ -29,5 +30,5 @@ post_remove() {
     if [ -L "$service_file_link" ]; then
         rm $service_file_link
     fi
-
+    rm -d /etc/optimus-manaer/optimus-manaer.conf
 }


### PR DESCRIPTION
原项目中并没有自动把Configuration标题下的`optimus-manager.conf`文件放入`/etc/optimus-manager中`，创建后的目录为`/etc/optimus-manager/optimus-manager.conf`，私以为加上后能更方便一些，以免自己打开网站自行添加