### PR TITLE
Fix kicad i18n switch errors

### DIFF
--- a/archlinuxcn/kicad-git/PKGBUILD
+++ b/archlinuxcn/kicad-git/PKGBUILD
@@ -32,6 +32,7 @@ build() {
     -DKICAD_USE_OCC=ON \
     -DKICAD_SCRIPTING_WXPYTHON=ON \
     -DKICAD_BUILD_I18N=ON \
+    -DKICAD_I18N_UNIX_STRICT_PATH=ON \
     -DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-gtk3 \
     -Wno-dev
 


### PR DESCRIPTION
修复 KiCad 的语言无法切换的问题
还没测试次方法是否有效，问题现象为：
![I5`4D)4DN@$6@JQ4QJ_C`J](https://user-images.githubusercontent.com/13965460/154930462-92e36e37-c30d-456c-9331-dae981b2ec50.png)
复现方式：kicad 界面偏好设置 -> 语言选择英文切换中文或中文切换英文
影响版本：kicad-v6.0 ~ 