### PR TITLE
haruna: add missing depends

### DIFF
--- a/archlinuxcn/haruna/PKGBUILD
+++ b/archlinuxcn/haruna/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Open source video player built with Qt/QML and libmpv'
 arch=('x86_64')
 url='https://invent.kde.org/multimedia/haruna'
 license=('GPL3')
-depends=('kfilemetadata' 'kio' 'mpv' 'kirigami2')
+depends=('kfilemetadata' 'kio' 'mpv' 'kirigami2' 'ffmpeg4.4')
 makedepends=('extra-cmake-modules' 'kdoctools')
 optdepends=('nvidia-utils: hardware accelerate support'
             'breeze: recommend theme'


### PR DESCRIPTION
`haruna` requires `ffmpeg4.4`. Without it, an error about missing `libavutil.so` file will be thrown.