### PR TITLE
fix fish-git

### DIFF
--- a/archlinuxcn/fish-git/PKGBUILD
+++ b/archlinuxcn/fish-git/PKGBUILD
@@ -6,8 +6,8 @@
 
 pkgname=fish-git
 _gitname="fish-shell"
-pkgver=3.4.0.r25.gc5a8764db
-pkgrel=56
+pkgver=3.4.1.r205.ga18be7b84
+pkgrel=1
 epoch=2
 pkgdesc="User friendly shell intended mostly for interactive use."
 arch=('i686' 'x86_64' 'arm')
@@ -21,7 +21,7 @@ makedepends=('cmake' 'python-sphinx' 'git' 'fish')
 provides=('fish' 'fish-shell')
 conflicts=('fish' 'fish-shell')
 install='fish.install'
-source=("git://github.com/fish-shell/fish-shell.git")
+source=("git+https://github.com/fish-shell/fish-shell.git")
 md5sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
source changed to git+https
caused by https://aur.archlinux.org/cgit/aur.git/commit/?h=fish-git&id=8a74fa0f47a7ae235e3ea7eed27c1efc40520d69

resolved #2747 