### PR TITLE
devtools-archlinuxcn: arch-nspawn: read CacheDir option from host's conf

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 pkgver=20200407
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
 license=('GPL')
@@ -15,8 +15,9 @@ optdepends=('btrfs-progs: btrfs support')
 provides=("devtools=$pkgver-$pkgrel")
 conflicts=("devtools")
 source=(https://sources.archlinux.org/other/${_pkgname}/${_pkgname}-${pkgver}.tar.gz{,.sig}
-        "no-yes-y.patch::https://git.archlinux.org/devtools.git/patch/?id=b7893a2ca8e09062197129881bce3fd6700a573a"
-        "unshare-pacstrap.patch")
+        "no-yes-y.patch"
+        "unshare-pacstrap.patch"
+        "arch-nspawn-read-CacheDir-from-host.patch")
 
 validpgpkeys=('487EACC08557AD082088DABA1EB2638FF56C0C53'
               '4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC'
@@ -30,12 +31,15 @@ validpgpkeys=('487EACC08557AD082088DABA1EB2638FF56C0C53'
 b2sums=('01ff4d17a9502df468d545e273e94ab7d7b6817efa6d7f2fe661b4a978a5051a03a8a04ea1e82902b30988413f32f65afdf49a234d82ab05fa510ffc52f62e02'
         'SKIP'
         '2da933aa8a0bce8acab22fcbdf857462a28bb313e4554b73cf4cb02dafb40ad124b71e5666cd88257dee8a1721a57e6659581026ab2ff21aa2c257df2397db0c'
-        'ad659b04b7b7a9111ceace6629e971ef775e73a2b68a82dc13d3dd5b732f3e7a056b3328fab54fa6b16e520212e4b5a6d5d27e1b0b87d10495c89a17ff130fc5')
+        'ad659b04b7b7a9111ceace6629e971ef775e73a2b68a82dc13d3dd5b732f3e7a056b3328fab54fa6b16e520212e4b5a6d5d27e1b0b87d10495c89a17ff130fc5'
+        '158a1e7608d804649b74e21ed54d5d8fd0f8f191eeb73f09347b9bc4795dd9cb88e68a25e37434a4ed7d964d2acae355b671953ed01ba1ca638a307bf9d5d7d1')
 
 prepare() {
   cd ${_pkgname}-${pkgver}
   patch -RNp1 -i ../no-yes-y.patch
   patch -Np1 -i ../unshare-pacstrap.patch
+  # Manual backport for devtools 20200407 from https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/95
+  patch -Np1 -i ../arch-nspawn-read-CacheDir-from-host.patch
 
   ## silent while show errors for curl
   sed "s|bin/curl -g|bin/curl -sS -g|g" -i makepkg-x86_64.conf

--- a/archlinuxcn/devtools-archlinuxcn/arch-nspawn-read-CacheDir-from-host.patch
+++ b/archlinuxcn/devtools-archlinuxcn/arch-nspawn-read-CacheDir-from-host.patch
@@ -1,0 +1,33 @@
+From d0847a2a1c5d183d8df9d9c7640a8f8e68455bc8 Mon Sep 17 00:00:00 2001
+From: Evangelos Foutras <evangelos@foutrelis.com>
+Date: Fri, 18 Mar 2022 17:16:24 +0200
+Subject: [PATCH] arch-nspawn: read CacheDir option from host's conf
+
+This went unnoticed on build.archlinux.org until we tried switching away
+from its local /srv/ftp/ mirror. With a remote mirror, the chroots would
+ignore all the cached packages under /srv/ftp/pool/{packages,community}.
+
+With the local file:// mirror gone, arch-nspawn wouldn't mount the cache
+directories from the host into the chroot. The fix is to read the option
+from the host's pacman.conf, instead of the one given to arch-nspawn and
+the one existing inside the working directory.
+---
+ arch-nspawn.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch-nspawn.in b/arch-nspawn.in
+index 275cff7..b6c9cb1 100644
+--- a/arch-nspawn.in
++++ b/arch-nspawn.in
+@@ -50,7 +50,7 @@ shift 1
+ pacconf_cmd=$(command -v pacman-conf || command -v pacconf)
+ 
+ if (( ${#cache_dirs[@]} == 0 )); then
+-	mapfile -t cache_dirs < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" CacheDir)
++	mapfile -t cache_dirs < <($pacconf_cmd CacheDir)
+ fi
+ 
+ # shellcheck disable=2016
+-- 
+GitLab
+


### PR DESCRIPTION
To get rid of race conditions around the default pacman cache dir during
concurrent builds

This should fix the issue. I checked modified `pacman-*.conf` files but didn't actually test it.
```
$ tar -xOf devtools-archlinuxcn-20200407-2-any.pkg.tar.zst usr/share/devtools/pacman-extra.conf | grep CacheDir
#CacheDir    = /var/cache/pacman/pkg/
CacheDir=/data/archlinux/pool/packages/
CacheDir=/data/archlinux/pool/community/
CacheDir=/data/repo/x86_64/
```
As this package is marked with `managed: false`, it should be manually built and upload. I can do it if @farseerfc is OK with that.