### PR TITLE
addpkg: watchman

### DIFF
--- a/archlinuxcn/watchman/PKGBUILD
+++ b/archlinuxcn/watchman/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Xuanrui Qi <me@xuanruiqi.com>
+# Contributor: Jean Lucas <jean@4ray.co>
+# Contributor: José Luis Lafuente <jl@lafuente.me>
+# Contributor: Michael Louis Thaler <michael.louis.thaler@gmail.com>
+
+pkgname=watchman
+pkgver=4.9.0
+pkgrel=6
+pkgdesc="An inotify-based file watching and job triggering command line utility"
+url="https://facebook.github.io/watchman/"
+arch=('i686' 'x86_64')
+license=('Apache')
+depends=('pcre' 'systemd' 'python')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/facebook/watchman/archive/v${pkgver}.tar.gz"
+        "${pkgname}.tmpfiles" "python3.patch" "autogen.patch")
+sha256sums=('1f6402dc70b1d056fffc3748f2fdcecff730d8843bb6936de395b3443ce05322'
+            '2b061865e10578a0477b9c7991a00594bc839c846b98896e93c75743dbf6a379'
+            '8aa32e37aef329e0873425d25e370d25b7aa0731f104a645737f1111f64a5a9e'
+            '1a86a52a434c034b4478af88f2789a1791e826f9ca4f1e8b1c421923b2dc2447')
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  patch -Np1 -i "${srcdir}"/autogen.patch
+  autoupdate
+  ./autogen.sh
+
+  patch -Np1 -i "${srcdir}"/python3.patch
+}
+
+build() {
+  cd ${pkgname}-${pkgver}
+  ./configure --prefix=/usr --disable-statedir --enable-lenient
+  make
+}
+
+check() {
+  cd ${pkgname}-${pkgver}
+  # TODO: fix segfault in test
+  #make check
+}
+
+package() {
+  cd ${pkgname}-${pkgver}
+  # Docs available online only; see https://github.com/facebook/watchman/issues/30
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm 644 "${srcdir}"/${pkgname}.tmpfiles "${pkgdir}"/usr/lib/tmpfiles.d/${pkgname}.conf
+}
+
+# vim:set ts=2 sw=2 et:

--- a/archlinuxcn/watchman/autogen.patch
+++ b/archlinuxcn/watchman/autogen.patch
@@ -1,0 +1,11 @@
+--- watchman-4.9.0/autogen.sh.old	2021-01-31 05:39:03.639533048 +0900
++++ watchman-4.9.0/autogen.sh	2021-01-31 05:39:36.825677454 +0900
+@@ -21,7 +21,7 @@
+ # should be the case provided pkg-config is installed AND the above commands
+ # have been run to prep the source tree with local set-up. 
+ CHECK_PKG_CONFIG_M4='m4_ifdef([PKG_CHECK_MODULES], [errprint([ok])])'
+-if [ "x$(autoconf <(echo "$CHECK_PKG_CONFIG_M4") 2>&1)" != "xok" ] ; then
++if [ "x$(autoconf -Wnone <(echo "$CHECK_PKG_CONFIG_M4") 2>&1)" != "xok" ] ; then
+   echo 'pkg-config appears to be missing (not available to autoconf tools)'
+   echo 'please install the pkg-config package for your system.'
+   exit 1

--- a/archlinuxcn/watchman/lilac.yaml
+++ b/archlinuxcn/watchman/lilac.yaml
@@ -1,0 +1,7 @@
+update_on:
+  - source: github
+    github: facebook/watchman
+    exclude_regex: v\d{4}.\d{2}.\d{2}.\d{2}
+
+maintainers:
+  - github: pickfire

--- a/archlinuxcn/watchman/python3.patch
+++ b/archlinuxcn/watchman/python3.patch
@@ -1,0 +1,51 @@
+diff -aur watchman-4.9.0.old/python/bin/watchman-make watchman-4.9.0/python/bin/watchman-make
+--- watchman-4.9.0.old/python/bin/watchman-make	2020-04-03 20:33:59.893048471 +0200
++++ watchman-4.9.0/python/bin/watchman-make	2020-04-03 20:36:21.800479512 +0200
+@@ -209,7 +209,7 @@
+         client.setTimeout(600)
+ 
+         result = client.receive()
+-        for _, t in targets.iteritems():
++        for _, t in targets.items():
+             t.consumeEvents(client)
+ 
+         # Now we wait for events to settle
+@@ -218,7 +218,7 @@
+         while not settled:
+             try:
+                 result = client.receive()
+-                for _, t in targets.iteritems():
++                for _, t in targets.items():
+                     t.consumeEvents(client)
+             except pywatchman.SocketTimeout as ex:
+                 # Our short settle timeout hit, so we're now settled
+@@ -226,7 +226,7 @@
+                 break
+ 
+         # Now we can work on executing the targets
+-        for _, t in targets.iteritems():
++        for _, t in targets.items():
+             t.execute()
+ 
+         # Print this at the bottom of the loop rather than the top
+diff -aur watchman-4.9.0.old/python/bin/watchman-wait watchman-4.9.0/python/bin/watchman-wait
+--- watchman-4.9.0.old/python/bin/watchman-wait	2020-04-03 20:33:59.893048471 +0200
++++ watchman-4.9.0/python/bin/watchman-wait	2020-04-03 20:36:46.413945264 +0200
+@@ -182,7 +182,7 @@
+ try:
+     client.capabilityCheck(
+         required=['term-dirname', 'cmd-watch-project', 'wildmatch'])
+-    for _, sub in subscriptions.iteritems():
++    for _, sub in subscriptions.items():
+         sub.start(client)
+ 
+ except pywatchman.CommandError as ex:
+@@ -200,7 +200,7 @@
+         # the client object will accumulate all subscription results
+         # over time, so we ask it to remove and return those values
+         # for each of the subscriptions
+-        for _, sub in subscriptions.iteritems():
++        for _, sub in subscriptions.items():
+             sub.emit(client)
+ 
+     except pywatchman.SocketTimeout as ex:

--- a/archlinuxcn/watchman/watchman.tmpfiles
+++ b/archlinuxcn/watchman/watchman.tmpfiles
@@ -1,0 +1,1 @@
+d /run/watchman 0777 root root


### PR DESCRIPTION
> All releases since 4.9.0 have been internal Facebook releases, and Facebook is neither testing that the code will build on non-FB systems, nor willing to support people outside of Facebook. Everyone outside of Facebook are supposed to use the binary builds. Sadly, it's the way it is at Facebook open source.
>
> https://aur.archlinux.org/packages/watchman#comment-794701

不知道 watchman-bin 会不会比较好呢，facebook 已经好久没更新了
