### PR TITLE
devtools-archlinuxcn: update to 20221002

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -2,10 +2,10 @@
 
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
-pkgver=20220621
-pkgrel=2
+pkgver=20221002
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=d00483e5374f9c5238eb52eb2f3f4087d6734b0e
+_tag=960f5915f5b639005a5352ea66abbfb29387c516
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
@@ -20,7 +20,7 @@ conflicts=("devtools")
 source=("$pkgname::git+https://github.com/archlinuxcn/devtools.git?signed#tag=$_tag")
 b2sums=('SKIP')
 validpgpkeys=(
-  '481C4474AF1572165AE4C6AF3FDDD575826C5C30'  # https://github.com/yan12125
+  'E62545315B012B69C8C94A1D56EC201BFC794362'  # https://github.com/yan12125
 )
 
 pkgver() {


### PR DESCRIPTION
[archlinuxcn commits](https://github.com/archlinuxcn/devtools/compare/archlinux:devtools:master...master) are rebased without any conflict. Tested commits:

* [Revert "makechrootpkg: when installing with -I, ensure package is installed"](https://github.com/archlinux/devtools/commit/b10e507f78bacadc5a1dce434687c9335bf9999f)
* [Change default BUILDTOOL to devtools-archlinuxcn](https://github.com/archlinux/devtools/commit/5321b99e7a1a755675615b149cec7b1b6b9f07bf)
* [Silent while show errors for curl](https://github.com/archlinux/devtools/commit/9a369623002cd3ba9922e0123a294014a38466ff)
* [Use x86_64 mirrors for x86_64_v3](https://github.com/archlinux/devtools/commit/82f5c9bbc8ac055790345975131afa552527f323)

The other two commits are not tested.

Seems there are no breaking changes in [upstream commits](https://github.com/archlinux/devtools/compare/20220621...20221002).

This PR also switches to my new signing key, which is now part of the archlinux-keyring package [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-keyring/-/commit/498a19d0c6dc6f508a20ed27746506e97b96b20b

