### PR TITLE
Fix: dependencies build failure for `clash-verge`

### DIFF
--- a/archlinuxcn/clash-meta/lilac.yaml
+++ b/archlinuxcn/clash-meta/lilac.yaml
@@ -17,5 +17,6 @@ update_on:
   - source: github
     github: MetaCubeX/Clash.Meta
     use_latest_release: true
+    prefix: v
   - source: aur
     aur: clash-meta

--- a/archlinuxcn/quickjs/lilac.yaml
+++ b/archlinuxcn/quickjs/lilac.yaml
@@ -3,8 +3,9 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build_script: |
-  update_pkgver_and_pkgrel(_G.newver)
+pre_build_script: aur_pre_build(maintainers=['aperez'])
+
+post_build: aur_post_build
 
 update_on:
   - source: aur


### PR DESCRIPTION
fix `lilac.yaml` for `quickjs` and `clash-meta`

see the following logs for detail
- https://build.archlinuxcn.org/packages/#/clash-meta/logs/1664828294
- https://build.archlinuxcn.org/packages/#/clash-verge/logs/1664828294
- https://build.archlinuxcn.org/packages/#/quickjs/logs/1664828292