### PR TITLE
devtools-archlinuxcn: update to 20221012

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -2,10 +2,10 @@
 
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
-pkgver=20221002
-pkgrel=2
+pkgver=20221012
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=960f5915f5b639005a5352ea66abbfb29387c516
+_tag=5d307186d678b23f23b1543912694e1e22777d8a
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')


### PR DESCRIPTION
[archlinuxcn commits](https://github.com/archlinuxcn/devtools/compare/archlinux:devtools:master...master) are rebased without any conflict. Tested commits:

* [Revert "makechrootpkg: when installing with -I, ensure package is installed"](https://github.com/archlinuxcn/devtools/commit/b3465c467898b3e862dd207c8097d446460aeaf0)
* [Change default BUILDTOOL to devtools-archlinuxcn](https://github.com/archlinuxcn/devtools/commit/3e253e0e513b8fe470803888c28043c44fa669ba)
* [Silent while show errors for curl](https://github.com/archlinuxcn/devtools/commit/a502f6127cce505cad0ac7f3de90114a8087872d)
* [Use x86_64 mirrors for x86_64_v3](https://github.com/archlinuxcn/devtools/commit/a13784f1246c06f1db24487a306fd03b621dcb69)

The other two commits are not tested.

Also, seems there are no breaking changes in [upstream commits](https://github.com/archlinux/devtools/compare/20221002...20221012).