### PR TITLE
fix: yuzu-early-access

### DIFF
--- a/archlinuxcn/yuzu-early-access/PKGBUILD
+++ b/archlinuxcn/yuzu-early-access/PKGBUILD
@@ -2,20 +2,20 @@
 
 _pkgname=yuzu
 pkgname=$_pkgname-early-access
-pkgver=3073
-pkgrel=2
+pkgver=3076
+pkgrel=1
 pkgdesc="An experimental open-source Nintendo Switch emulator/debugger (early access version)"
 arch=('i686' 'x86_64')
 url="https://yuzu-emu.org/"
 license=('GPL2')
 depends=('boost-libs' 'shared-mime-info' 'hicolor-icon-theme' 'sdl2' 'qt5-base' 'qt5-multimedia' 'qt5-webengine' 'libxkbcommon-x11' 'ffmpeg' 'fmt' 'libzip' 'opus' 'libfdk-aac' 'lz4' 'mbedtls' 'openssl' 'zstd')
-makedepends=('git' 'glslang' 'cmake' 'ninja' 'graphviz' 'doxygen' 'clang' 'boost' 'catch2' 'nlohmann-json' 'rapidjson' 'qt5-tools' 'desktop-file-utils' 'robin-map')
+makedepends=('git' 'glslang' 'cmake' 'ninja' 'graphviz' 'doxygen' 'clang' 'boost' 'catch2' 'nlohmann-json' 'rapidjson' 'qt5-tools' 'desktop-file-utils' 'robin-map' 'llvm')
 optdepends=('qt5-wayland: for Wayland support')
 provides=('yuzu')
 conflicts=('yuzu')
 source=("https://github.com/pineappleEA/pineapple-src/archive/EA-${pkgver}.tar.gz"
 "https://raw.githubusercontent.com/pineappleEA/Pineapple-Linux/master/yuzu.xml")
-sha256sums=('4f8baca093fb67ee03cc0426438a11c0380a9c87cce503c48a25e2c414122907'
+sha256sums=('73c84a0db29d9225ff8d9ef8b345c14a09eef63386b4f1d27399b7007c8f09f7'
             'e76ab2b3566d8135930e570ede5bed3da8f131270b60db818e453d248880bdf2')
 
 prepare() {
@@ -39,6 +39,7 @@ build() {
   cmake .. -GNinja \
     -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_AR=/usr/bin/llvm-ar \
     -DCMAKE_C_FLAGS="$CFLAGS -flto=thin" \
     -DCMAKE_CXX_FLAGS="$CXXFLAGS -flto=thin" \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \


### PR DESCRIPTION
`yuzu-early-access` fails to be built because `CMAKE_AR` is not defined.
For a detailed log, see https://build.archlinuxcn.org/packages/#/yuzu-early-access/logs/1667420698


Use `llvm-ar` since we are using `clang` (instead of `gcc`) as compiler.