### PR TITLE
oh-my-posh: 不随AUR更新

### DIFF
--- a/archlinuxcn/oh-my-posh/lilac.yaml
+++ b/archlinuxcn/oh-my-posh/lilac.yaml
@@ -15,5 +15,3 @@ update_on:
     github: JanDeDobbeleer/oh-my-posh
     use_latest_release: true
     prefix: v
-  - source: aur
-    aur: oh-my-posh


### PR DESCRIPTION
AUR上的更新和这里的自动更新基本上是重复的，当AUR更新后这里会对`pkgrel`进行更新生成一个与`x.x.x-1`一模一样的`x.x.x-2`，没有意义