### PR TITLE
devtools-archlinuxcn: fix pacstrap incompatibility

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -3,10 +3,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 pkgver=20221012
-pkgrel=2
-# curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=5d307186d678b23f23b1543912694e1e22777d8a
-_upstream_pkgrel=1
+pkgrel=3
+# curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn2 | jq -r .object.sha
+_tag=1249cadb2edb5aa73477eb248dc854fcf365b479
+_upstream_pkgrel=2
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
 license=('GPL')


### PR DESCRIPTION
Also bumps $_upstream_pkgrel following
https://github.com/archlinux/svntogit-packages/commit/558e0aad0c4a123ad8602f4cc5af7a149785c1d6

Closes https://github.com/archlinuxcn/repo/issues/3060