### PR TITLE
修复 clash-meta 使用 tun 模式时的打包错误

### DIFF
--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -26,13 +26,16 @@ sha256sums=('8f11a82a2eb24d8c0aea027b4674cc6d4165c2f7c8e9c7e136b7961f4ce22bf8'
 
 build(){
     cd "${srcdir}"/Clash.Meta-${pkgver}
-
+    BUILDTIME=$(date -u)
     GOOS=linux CGO_ENABLED=0 go build \
     -trimpath \
     -buildmode=pie \
     -mod=readonly \
     -modcacherw \
-    -ldflags "-linkmode external -extldflags \"${LDFLAGS}\"" \
+    -ldflags "-linkmode external -extldflags \"${LDFLAGS}\" \
+    -X \"github.com/Dreamacro/clash/constant.Version=${pkgver}\" \
+    -X \"github.com/Dreamacro/clash/constant.BuildTime=${BUILDTIME}\" \
+    " \
     -tags with_gvisor -o ${pkgname}-${pkgver}
 }
 package() {

--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -8,7 +8,7 @@ arch=("x86_64" 'aarch64')
 url="https://github.com/MetaCubeX/Clash.Meta"
 license=("GPL3")
 depends=('glibc' 'clash-geoip')
-makedepends=('go' 'libcap')
+makedepends=('go')
 conflicts=(clash-meta)
 backup=('etc/clash-meta/config.yaml')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
@@ -44,7 +44,6 @@ package() {
     install -Dm644 "config.yaml" -t "${pkgdir}/etc/clash-meta"
     install -Dm644 "clash-meta.service"  -t "${pkgdir}/usr/lib/systemd/system"
     install -Dm644 "clash-meta@.service" -t "${pkgdir}/usr/lib/systemd/system"
-    setcap cap_net_bind_service,cap_net_admin=+ep "${pkgdir}"/usr/bin/clash-meta
     ln -sf /etc/clash/Country.mmdb ${pkgdir}/etc/${pkgname}/Country.mmdb
     #geosite.dat from community repo does not work
     # ln -sf /usr/share/v2ray/geosite.dat ${pkgdir}/etc/${pkgname}/GeoSite.dat

--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -8,7 +8,7 @@ arch=("x86_64" 'aarch64')
 url="https://github.com/MetaCubeX/Clash.Meta"
 license=("GPL3")
 depends=('glibc' 'clash-geoip')
-makedepends=('go')
+makedepends=('go' 'libcap')
 conflicts=(clash-meta)
 backup=('etc/clash-meta/config.yaml')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
@@ -26,8 +26,14 @@ sha256sums=('8f11a82a2eb24d8c0aea027b4674cc6d4165c2f7c8e9c7e136b7961f4ce22bf8'
 
 build(){
     cd "${srcdir}"/Clash.Meta-${pkgver}
-    GOOS=linux  go build  -o ${pkgname}-${pkgver}
 
+    GOOS=linux CGO_ENABLED=0 go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-linkmode external -extldflags \"${LDFLAGS}\"" \
+    -tags with_gvisor -o ${pkgname}-${pkgver}
 }
 package() {
     cd "${srcdir}"/Clash.Meta-${pkgver}
@@ -38,7 +44,7 @@ package() {
     install -Dm644 "config.yaml" -t "${pkgdir}/etc/clash-meta"
     install -Dm644 "clash-meta.service"  -t "${pkgdir}/usr/lib/systemd/system"
     install -Dm644 "clash-meta@.service" -t "${pkgdir}/usr/lib/systemd/system"
-
+    setcap cap_net_bind_service,cap_net_admin=+ep "${pkgdir}"/usr/bin/clash-meta
     ln -sf /etc/clash/Country.mmdb ${pkgdir}/etc/${pkgname}/Country.mmdb
     #geosite.dat from community repo does not work
     # ln -sf /usr/share/v2ray/geosite.dat ${pkgdir}/etc/${pkgname}/GeoSite.dat


### PR DESCRIPTION
编译时包含 tun 模式必要的 gvisor 
https://github.com/MetaCubeX/Clash.Meta/blob/667f42dcdcaacfef0c6cd84d38267d5971315f0d/Makefile#L15

添加使用 tun 模式时必要的 capabilities
https://github.com/zzzgydi/clash-verge/issues/182