### PR TITLE
devtools-archlinuxcn: update to 20230105

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -2,11 +2,11 @@
 
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
-pkgver=20221012
-pkgrel=4
-# curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn2 | jq -r .object.sha
-_tag=1249cadb2edb5aa73477eb248dc854fcf365b479
-_upstream_pkgrel=2
+pkgver=20230105
+pkgrel=1
+# curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
+_tag=980db35c567ba7c118fb1f62a599609348bb108f
+_upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
 license=('GPL')


### PR DESCRIPTION
[archlinuxcn commits](https://github.com/archlinuxcn/devtools/compare/archlinux:devtools:master...master) are rebased without any conflict. This time I test only the new archlinuxcn-specific patch (https://github.com/archlinuxcn/devtools/pull/1) and skip existing ones.

There is one noticeable change in [upstream commits](https://github.com/archlinux/devtools/compare/20221012...20230105): debug packages are enabled by default. There are already several debug packages in [archlinuxcn], so it should work in general. Possible issues may include broken builds with debug flags or disk usage for mirrors.