### PR TITLE
librime-sbxlm: fix build error with gtest-1.13

### DIFF
--- a/archlinuxcn/librime-sbxlm-git/0001-fix-build.patch
+++ b/archlinuxcn/librime-sbxlm-git/0001-fix-build.patch
@@ -1,15 +1,29 @@
-From ea62273a836251ef2d0f616d919c4b1378e318fa Mon Sep 17 00:00:00 2001
+From 0ecaa4e36098f8d7bd1694b31373ad4236771137 Mon Sep 17 00:00:00 2001
 From: ZeekoZhu <vaezt@outlook.com>
-Date: Tue, 19 Apr 2022 00:54:26 +0800
-Subject: [PATCH] patch build
+Date: Thu, 26 Jan 2023 21:23:09 +0800
+Subject: [PATCH] fix: fix build on archlinux
 
 ---
+ CMakeLists.txt                     | 2 +-
  src/rime/gear/script_translator.cc | 1 +
  src/rime/gear/table_translator.cc  | 1 +
  3 files changed, 3 insertions(+), 1 deletion(-)
 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 96e0ef9d..2bf81898 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -159,7 +159,7 @@ if(MSVC)
+ endif()
+ 
+ if(UNIX)
+-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+ endif()
+ 
+ if(NOT DEFINED LIB_INSTALL_DIR)
 diff --git a/src/rime/gear/script_translator.cc b/src/rime/gear/script_translator.cc
-index 00b4f110..caabf4e8 100644
+index f243335e..31c666a7 100644
 --- a/src/rime/gear/script_translator.cc
 +++ b/src/rime/gear/script_translator.cc
 @@ -23,6 +23,7 @@
@@ -21,7 +35,7 @@ index 00b4f110..caabf4e8 100644
  
  //static const char* quote_left = "\xef\xbc\x88";
 diff --git a/src/rime/gear/table_translator.cc b/src/rime/gear/table_translator.cc
-index a5bf83f9..b726ce3e 100644
+index 6d6d529f..b8fbcd8e 100644
 --- a/src/rime/gear/table_translator.cc
 +++ b/src/rime/gear/table_translator.cc
 @@ -22,6 +22,7 @@
@@ -33,5 +47,5 @@ index a5bf83f9..b726ce3e 100644
  namespace rime {
    
 -- 
-2.35.3
+2.39.1
 


### PR DESCRIPTION
gtest 1.13 不再支持 c++ 11 了，需要将 c++ standard 设置为 c++14 ，经过测试后能够使用，这段文字就是用这个 patch 后的版本输入的