### PR TITLE
Update kicad-library-git

### DIFF
--- a/archlinuxcn/kicad-library-git/PKGBUILD
+++ b/archlinuxcn/kicad-library-git/PKGBUILD
@@ -1,19 +1,22 @@
 # Mainainer: edward-p <edward at edward-p dot xyz>
+# Mainainer: taotieren <admin@taotieren.com>
 
 pkgname=kicad-library-git
 pkgver=7.0.0.rc2.r3.g72a460351
 pkgrel=1
-pkgdesc="Kicad component and footprint libraries"
+pkgdesc="KiCad symbol, footprint and template libraries"
 arch=('any')
-url="https://kicad.github.io/"
-license=('GPL')
+url="https://klc.kicad.org/"
+license=('CC-BY-SA 4.0')
 makedepends=('cmake' 'git')
 options=('!strip')
 source=("git+https://gitlab.com/kicad/libraries/kicad-footprints.git"
-        "git+https://gitlab.com/kicad/libraries/kicad-symbols.git")
+        "git+https://gitlab.com/kicad/libraries/kicad-symbols.git"
+        "git+https://gitlab.com/kicad/libraries/kicad-templates.git")
 provides=('kicad-library')
 conflicts=('kicad-library')
 sha256sums=('SKIP'
+            'SKIP'
             'SKIP')
 
 pkgver() {
@@ -29,14 +32,21 @@ build() {
   cd "$srcdir/kicad-footprints/"
   cmake ./ -DCMAKE_INSTALL_PREFIX=/usr
   make
+
+  cd "$srcdir/kicad-templates/"
+  cmake ./ -DCMAKE_INSTALL_PREFIX=/usr
+  make
+
 }
 
 package() {
-  pkgdesc="Kicad component and footprint libraries"
   cd "$srcdir/kicad-symbols/"
   make DESTDIR="$pkgdir" install
 
   cd "$srcdir/kicad-footprints/"
+  make DESTDIR="$pkgdir" install
+
+  cd "$srcdir/kicad-templates/"
   make DESTDIR="$pkgdir" install
 }
 

--- a/archlinuxcn/kicad-library-git/lilac.yaml
+++ b/archlinuxcn/kicad-library-git/lilac.yaml
@@ -1,6 +1,7 @@
 maintainers:
   - github: edward-p
   - github: MarvelousBlack
+  - github: taotieren
 
 build_prefix: extra-x86_64
 
@@ -13,3 +14,5 @@ update_on:
     gitlab: kicad/libraries/kicad-symbols
   - source: gitlab
     gitlab: kicad/libraries/kicad-footprints
+  - source: gitlab
+    gitlab: kicad/libraries/kicad-templates


### PR DESCRIPTION
在更新 KiCad 手册中发现 `kicad-library-git` 包里面少了模板文件，现在更新加入模板文件。