### PR TITLE
Add notepad---git

### DIFF
--- a/archlinuxcn/notepad---git/PKGBUILD
+++ b/archlinuxcn/notepad---git/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: taotieren <admin@taotieren.com>
+
+pkgname=notepad---git
+pkgver=1.22.r9.gb9b2083
+pkgrel=1
+pkgdesc="Notepad-- 是一个简单的国产跨平台文本编辑器，是替换 Notepad++ 的一种选择。其内置强大的代码对比功能，让你丢掉付费的 Beyond Compare。"
+arch=('x86_64')
+url="https://gitee.com/cxasm/notepad--"
+license=('GPL3')
+provides=(${pkgname%-git})
+conflicts=(${pkgname%-git})
+depends=(qt5-base
+        qt5-xmlpatterns)
+makedepends=(git
+            qt5-tools)
+source=("${pkgname}::git+${url}.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${pkgname}/"
+    git describe --long --tags | sed 's/v//g;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+    cd "${srcdir}/${pkgname}/src/qscint/src/"
+    qmake-qt5 -makefile -o Makefile "CONFIG+=release"
+    make
+
+    cd "${srcdir}/${pkgname}/src/"
+    qmake-qt5 -makefile -o Makefile "CONFIG+=release"
+    make
+}
+
+package() {
+    cp -ra "${srcdir}"/${pkgname}/src/linux/*  "$pkgdir"/
+    install -Dm0755 "${srcdir}/${pkgname}/src/x64/Release/Notepad--" "${pkgdir}/usr/bin/${pkgname%-git}"
+}

--- a/archlinuxcn/notepad---git/lilac.yaml
+++ b/archlinuxcn/notepad---git/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: taotieren
+
+build_prefix: extra-x86_64
+
+pre_build: vcs_update
+
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+
+update_on:
+  - source: git
+    git: https://gitee.com/cxasm/notepad--.git
+    use_commit: true


### PR DESCRIPTION
notepad--是一个国产跨平台、简单的文本编辑器，是替换notepad++的一种选择。其内置强大的代码对比功能，让你丢掉付费的beyond compare。