### PR TITLE
Update kicad-git

### DIFF
--- a/archlinuxcn/kicad-git/PKGBUILD
+++ b/archlinuxcn/kicad-git/PKGBUILD
@@ -18,6 +18,7 @@ depends=(
   'python-wxpython'
   'wxwidgets-gtk3'
   'unixodbc'
+  'kicad-library'
 )
 makedepends=(
   'git'
@@ -27,7 +28,7 @@ makedepends=(
   'swig'
   'ninja'
 )
-optdepends=('kicad-library: for footprints')
+optdepends=('kicad-library-3d: KiCad 3D render model libraries')
 conflicts=('kicad' 'kicad-bzr')
 provides=('kicad')
 source=("${pkgname}"'::git+https://gitlab.com/kicad/code/kicad.git')


### PR DESCRIPTION
目前 KiCad 没有处理不安装符号和封装的功能，如果不安装的话会出现全局库不可修改的问题，影响 KiCad 工程中的符号和封装的显示。3D 封装可以后期安装不影响显示。