### PR TITLE
`miktex`: update_on alias: `boost-libs`

### DIFF
--- a/archlinuxcn/miktex/lilac.yaml
+++ b/archlinuxcn/miktex/lilac.yaml
@@ -9,3 +9,4 @@ update_on:
     github: MiKTeX/miktex
     use_latest_release: true
   - alias: icu
+  - alias: boost-libs


### PR DESCRIPTION
Fix `error while loading shared libraries: libboost_locale.so.1.80.0: cannot open shared object file: No such file or directory`