### PR TITLE
clash-verge: rm libappindicator-gtk3 from depends

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: sukanka<su975853527 AT gmail dot com>
 pkgname=clash-verge
 pkgver=1.2.3
-pkgrel=2
+pkgrel=3
 pkgdesc="A Clash GUI based on tauri."
 arch=('x86_64' 'aarch64')
 url="https://github.com/zzzgydi/clash-verge"
 license=('GPL3')
-depends=('webkit2gtk' 'clash-geoip' 'libappindicator-gtk3' 'libayatana-appindicator')
+depends=('webkit2gtk' 'clash-geoip' 'libayatana-appindicator')
 makedepends=('yarn' 'cargo-tauri' 'clash-premium-bin' 'clash-meta'  'jq' 'moreutils' 'rust' 'quickjs')
 optdepends=('clash-premium-bin>=2022.04.01: clash-core'
 'clash-meta: clash-core')


### PR DESCRIPTION
According  to [tauri doc](https://tauri.app/v1/guides/features/system-tray/#linux-setup), only one of  `'libappindicator-gtk3'` `'libayatana-appindicator'` is needed, but  ` libappindicator-gtk3` breaks left-mouse actions for most applications Edit, see https://bugs.launchpad.net/ubuntu/+source/libappindicator/+bug/1910521

we decide to remove it from `depends` list.

Thank [stonemoe](https://aur.archlinux.org/account/stonemoe) from AUR for informing me of this.