### PR TITLE
logseq-desktop: fix dir permission for non-root

### DIFF
--- a/archlinuxcn/logseq-desktop/PKGBUILD
+++ b/archlinuxcn/logseq-desktop/PKGBUILD
@@ -55,6 +55,7 @@ package() {
 
     # create destination folder and copy files
     mkdir -p "${pkgdir}/opt/${pkgname}"
+    chmod 0755 "${pkgdir}/opt/${pkgname}"
     cp -a -r -u --verbose ./ "${pkgdir}/opt/${pkgname}"
 
     # create a soft link to the executable


### PR DESCRIPTION
我安装 `logseq-desktop 0.8.17-2` 后 /opt/logseq-desktop是0700权限, 导致一般用户无法执行

打包前chmod一次应该能避免这个错误