### PR TITLE
update kicad-library-git

### DIFF
--- a/archlinuxcn/kicad-library-git/PKGBUILD
+++ b/archlinuxcn/kicad-library-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Mainainer: taotieren <admin@taotieren.com>
 
 pkgname=kicad-library-git
-pkgver=7.0.0.rc2.r16.gcc47a9b25
+pkgver=7.0.0.r16.gefc1e4107
 pkgrel=1
 pkgdesc="KiCad symbol, footprint and template libraries"
 arch=('any')
@@ -21,7 +21,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd kicad-footprints
-  git describe --long | sed 's/-rc/rc/;s/\([^-]*-g\)/r\1/;s/-/./g'
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
             
 build() {


### PR DESCRIPTION
> 包 kicad-library-git 打的版本为 7.0.0rc2.r32.g1e61f5d42-1，但在仓库里已有较新版本 7.0.0.rc2.r16.gcc47a9b25-1。

修复 lilac 提示版本信息错误