### PR TITLE
修复 clash-meta 的 clash-meta@.service 文件错误

### DIFF
--- a/archlinuxcn/clash-meta/clash-meta@.service
+++ b/archlinuxcn/clash-meta/clash-meta@.service
@@ -5,8 +5,8 @@ After=network.target NetworkManager.service systemd-networkd.service iwd.service
 [Service]
 Type=exec
 User=%i
-CapabilityBoundingSet=cap_net_admin
-AmbientCapabilities=cap_net_admin
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
 Restart=on-abort
 ExecStart=/usr/bin/clash-meta
 


### PR DESCRIPTION
clash-meta@sevice服务的CapabilityBoundingSet和AmbientCapabilities有问题，导致无法systemctl无法使用非root用户成功启动服务，这应修改为与Clash.Meta文档一样 https://github.com/MetaCubeX/Clash.Meta#general-installation-guide-for-linux

CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE