### PR TITLE
devtools-archlinuxcn: update to 20230307

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -2,10 +2,10 @@
 
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
-pkgver=20230105
-pkgrel=2
+pkgver=20230307
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=4240649fc796e1262ff4158bda127eb34225f8c8
+_tag=d54651181bc857b1839f8cbab446389c936be459
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')

--- a/archlinuxcn/devtools-archlinuxcn/lilac.yaml
+++ b/archlinuxcn/devtools-archlinuxcn/lilac.yaml
@@ -1,5 +1,7 @@
 maintainers:
   - github: farseerfc
+  - github: yan12125
+    email: f2q9sf79f9owdg2o@chyen.cc
 
 post_build: git_pkgbuild_commit
 


### PR DESCRIPTION
Also adds myself to maintainers, so that I can receive package notifications

---

I will still use pull requests to update this package in the future, so that people can have a look before new devtools enter [archlinuxcn].

There is one conflict: the patch from https://github.com/archlinuxcn/devtools/pull/1 conflicts with another one from https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/122. With a quick test, the option `-t` seems still working. I didn't test other archlinuxcn-specific patches.

Also, seems there are no breaking changes in [upstream commits](https://github.com/archlinux/devtools/compare/20230105...20230307).