### PR TITLE
fix(librime-sbxlm-git): remove c++14 flag patch

### DIFF
--- a/archlinuxcn/librime-sbxlm-git/0001-fix-build.patch
+++ b/archlinuxcn/librime-sbxlm-git/0001-fix-build.patch
@@ -4,24 +4,10 @@ Date: Thu, 26 Jan 2023 21:23:09 +0800
 Subject: [PATCH] fix: fix build on archlinux
 
 ---
- CMakeLists.txt                     | 2 +-
  src/rime/gear/script_translator.cc | 1 +
  src/rime/gear/table_translator.cc  | 1 +
  3 files changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 96e0ef9d..2bf81898 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -159,7 +159,7 @@ if(MSVC)
- endif()
- 
- if(UNIX)
--  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
- endif()
- 
- if(NOT DEFINED LIB_INSTALL_DIR)
 diff --git a/src/rime/gear/script_translator.cc b/src/rime/gear/script_translator.cc
 index f243335e..31c666a7 100644
 --- a/src/rime/gear/script_translator.cc

--- a/archlinuxcn/librime-sbxlm-git/PKGBUILD
+++ b/archlinuxcn/librime-sbxlm-git/PKGBUILD
@@ -5,7 +5,7 @@
 
 _pkgname=librime
 pkgname=$_pkgname-sbxlm-git
-pkgver=1.4.0.r429.ge613a1b1
+pkgver=9.5.2.r0.g8040f672
 _octagramcommit=f92e083052b9983ee3cbddcda5ed60bb3c068e24
 _luacommit=d45a41af2f9d731e3c1516a191cc3160e3cb8377
 pkgrel=1


### PR DESCRIPTION
上游已经更新到 c++14 了，移除设置 c++14 的 patch，修复打包失败的问题