### PR TITLE
elan-lean: add aarch64 support

### DIFF
--- a/alarmcn/elan-lean/PKGBUILD
+++ b/alarmcn/elan-lean/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Ray Xu <i@xugr.me>
+# Contributor: Xuanrui QI <me@xuanruiqi.com>
+
+# This PKGBUILD is forked off the PKGBUILD for rustup, which is 
+# the work of:
+# Maintainer: Sven-Hendrik Haase <svenstaro@gmail.com>
+# Contributor: Jonathon Fernyhough <jonathon_at_manjaro_dot_org>
+# Contributor: Jon Gjengset <jon@tsp.io>
+_pkgname=elan
+pkgname=${_pkgname}-lean
+pkgver=1.4.2
+pkgrel=3
+pkgdesc="A Lean version manager"
+arch=('x86_64' 'aarch64')
+url="https://github.com/leanprover/elan"
+license=('MIT' 'Apache')
+depends=('curl' 'xz')
+makedepends=('cargo')
+provides=('lean-community')
+conflicts=('lean-bin' 'lean-git' 'lean4' 'lean-community' )
+install='post.install'
+source=("elan-${pkgver}.tar.gz::https://github.com/leanprover/elan/archive/v${pkgver}.tar.gz")
+_binlinks=('lean' 'leanpkg' 'leanchecker' 'leanc' 'leanmake' 'lake')
+sha512sums=('3f8adfca2f24e40d74eface26cf76346ec6f2a02d36f7a664ef4df48f1eabba27e8d10c3effa878dbb9ffee2d3524f96f4c45d2fba49b990324d03e62d1d1fe8')
+options=(!lto)
+
+build() {
+    cd "$srcdir/$_pkgname-${pkgver}"
+    cargo build --release --features no-self-update --bin elan-init
+}
+
+package() {
+    cd "$_pkgname-${pkgver}"
+    install -Dm755 "target/release/elan-init" "${pkgdir}/usr/bin/elan"
+    for link in "${_binlinks[@]}"; do
+        ln -s /usr/bin/elan "${pkgdir}/usr/bin/${link}"
+    done
+
+    # Generate completion files.
+    mkdir -p "$pkgdir/usr/share/bash-completion/completions"
+    "$pkgdir"/usr/bin/elan completions bash > "$pkgdir/usr/share/bash-completion/completions/elan"
+    mkdir -p "$pkgdir/usr/share/fish/vendor_completions.d"
+    "$pkgdir"/usr/bin/elan completions fish > "$pkgdir/usr/share/fish/vendor_completions.d/elan.fish"
+    mkdir -p "$pkgdir/usr/share/zsh/site-functions"
+    "$pkgdir"/usr/bin/elan completions zsh > "$pkgdir/usr/share/zsh/site-functions/_elan"
+
+    install -Dm644 LICENSE-MIT "${pkgdir}"/usr/share/licenses/$pkgname/LICENSE-MIT
+    install -Dm644 LICENSE-APACHE "${pkgdir}"/usr/share/licenses/$pkgname/LICENSE-APACHE
+}
+
+# vim:filetype=sh:

--- a/alarmcn/elan-lean/lilac.yaml
+++ b/alarmcn/elan-lean/lilac.yaml
@@ -1,0 +1,11 @@
+maintainers:
+  - github: megrxu
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    github: leanprover/elan
+    use_latest_release: true

--- a/alarmcn/elan-lean/post.install
+++ b/alarmcn/elan-lean/post.install
@@ -1,0 +1,8 @@
+post_install() {
+	echo "You may need to run elan update stable"
+	echo "and possibly also elan self upgrade-data"
+}
+
+post_upgrade() {
+	echo "You may need to run elan self upgrade-data"
+}

--- a/archlinuxcn/elan-lean/PKGBUILD
+++ b/archlinuxcn/elan-lean/PKGBUILD
@@ -9,9 +9,9 @@
 _pkgname=elan
 pkgname=${_pkgname}-lean
 pkgver=1.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A Lean version manager"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://github.com/leanprover/elan"
 license=('MIT' 'Apache')
 depends=('curl' 'xz')


### PR DESCRIPTION
This PR add support for aarch64 for package elan-lean.

[lean4-nightly](https://github.com/leanprover/lean4-nightly/releases) 提供了 lean4 的对应架构的二进制版本，asahi 用户也可以使用。