### PR TITLE
add amd-vulkan-prefixes

### DIFF
--- a/archlinuxcn/amd-vulkan-prefixes/PKGBUILD
+++ b/archlinuxcn/amd-vulkan-prefixes/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Andrew Shark <ashark on linuxcomp.ru>
+pkgname=amd-vulkan-prefixes
+pkgver=1
+pkgrel=1
+pkgdesc="Select needed vulkan implementation with vk_radv, vk_amdvlk or vk_pro prefix"
+arch=('any')
+license=('GPL')
+url="https://gitlab.com/AndrewShark/amd-vulkan-prefixes"
+source=(https://gitlab.com/AndrewShark/amd-vulkan-prefixes/-/raw/main/amd_vulkan_prefixes.sh
+        https://gitlab.com/AndrewShark/amd-vulkan-prefixes/-/raw/main/amd_vulkan_prefixes.bash-completion)
+sha256sums=("0ae2ff8bac00b0ce0330bafcfc8142576f432706843f6a681d357e410fdafae3"
+            "aaf96ea2ae87c7dab678e8a33986199256312dd70004aec87b5fd0f8b65ebaef")
+
+
+package() {
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.sh "${pkgdir}"/usr/bin/vk_radv
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.sh "${pkgdir}"/usr/bin/vk_amdvlk
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.sh "${pkgdir}"/usr/bin/vk_pro
+
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.bash-completion "${pkgdir}"/usr/share/bash-completion/completions/vk_radv
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.bash-completion "${pkgdir}"/usr/share/bash-completion/completions/vk_amdvlk
+    install -Dm755 "${srcdir}"/amd_vulkan_prefixes.bash-completion "${pkgdir}"/usr/share/bash-completion/completions/vk_pro
+}

--- a/archlinuxcn/amd-vulkan-prefixes/lilac.yaml
+++ b/archlinuxcn/amd-vulkan-prefixes/lilac.yaml
@@ -1,0 +1,12 @@
+pre_build_script: aur_pre_build(maintainers=['Ashark'])
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: amd-vulkan-prefixes
+  - source: manual
+    manual: 1.0
+
+maintainers:
+  - github: matrikslee


### PR DESCRIPTION
as the amdgpu users, we can use the scripts in this package
  to chose the specify vulkan driver for application that use graphics gpu

the wiki page [Vulkan#Selecting_via_AMD_Vulkan_Prefixes](https://wiki.archlinux.org/title/Vulkan#Selecting_via_AMD_Vulkan_Prefixes) and cnwiki [Vulkan#通过_AMD_Vulkan_Prefixes_选择](https://wiki.archlinuxcn.org/wiki/Vulkan#%E9%80%9A%E8%BF%87_AMD_Vulkan_Prefixes_%E9%80%89%E6%8B%A9) also references the package exactly