### PR TITLE
clash-meta: updpkgsums

### DIFF
--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=clash-meta
 pkgver=1.14.4
-pkgrel=2
+pkgrel=3
 pkgdesc="Another Clash Kernel by MetaCubeX"
 arch=("x86_64" 'aarch64')
 url="https://github.com/MetaCubeX/Clash.Meta"
@@ -17,7 +17,7 @@ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz
         "${pkgname}.sysusers"
         "${pkgname}.tmpfiles"
         "config.yaml")
-sha256sums=('bb34b63b27607d6f74083d79360b7b7f2876eff011d76bad6ef3159506e23e5f'
+sha256sums=('124c3da2166c0f8318ee1e6d182de8236127ff14493deb041539753b541cfa96'
             'b6b7ce11489a6f6322a41ce840b3f999b1ec88914f8bd6864c220269231bf759'
             'ec4de877464e595124a5f2752c3f4be157adc85ec5f7f8392c0331cb70fc906a'
             '655e8e2edcd82a6bdf2fd12430b7ab6f8e32db8dffce70e7342685a7cc65ebfb'


### PR DESCRIPTION
Hello, I'm the maintainer of this package in [AUR](https://aur.archlinux.org/packages/clash-meta). 
I don't know why its shasum should be wrong but when I run `updpkgsums` it changes indeed. 
This pr corrects its shasum.