### PR TITLE
chore: update motrix electron depend version

### DIFF
--- a/archlinuxcn/motrix/PKGBUILD
+++ b/archlinuxcn/motrix/PKGBUILD
@@ -3,14 +3,14 @@
 pkgname=motrix
 _pkgname=Motrix
 pkgver=1.8.17
-pkgrel=1
+pkgrel=2
 epoch=
 pkgdesc="A full-featured download manager (release version)"
 arch=("x86_64")
 url="https://github.com/agalwood/Motrix"
 license=('MIT')
 groups=()
-depends=('gtk3' 'libxcb' 'electron')
+depends=('gtk3' 'libxcb' 'electron22')
 makedepends=('npm' 'yarn' 'nodejs' 'python')
 checkdepends=()
 optdepends=()

--- a/archlinuxcn/motrix/motrix
+++ b/archlinuxcn/motrix/motrix
@@ -1,3 +1,3 @@
 #!/bin/bash
 export ELECTRON_IS_DEV=0
-exec /usr/bin/electron /usr/lib/motrix/app.asar
+exec /usr/bin/electron22 /usr/lib/motrix/app.asar "$@"


### PR DESCRIPTION
See also https://github.com/agalwood/Motrix/blob/master/yarn.lock#L3282

`electron11-bin` `electron13-bin` `electron18-bin` `electron19` already installed:
```
local/electron11-bin 11.5.0-2
    Build cross platform desktop apps with web technologies - version 11 - binary version
local/electron13-bin 13.6.9-1
    Build cross platform desktop apps with web technologies - binary version 13
local/electron18-bin 18.3.15-1
    Build cross platform desktop apps with web technologies - binary version 18
local/electron19 19.1.9-5
    Build cross platform desktop apps with web technologies
```
but when ran `motrix`
```
$ motrix
/usr/bin/motrix: line 3: /usr/bin/electron: No such file or directory
```
and only [community/electron](https://archlinux.org/packages/community/x86_64/electron) provides `/usr/bin/electron`.