### PR TITLE
gdb-multiarch: disable build for simulators

### DIFF
--- a/archlinuxcn/gdb-multiarch/PKGBUILD
+++ b/archlinuxcn/gdb-multiarch/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gdb-multiarch
 pkgver=13.1
-pkgrel=1
+pkgrel=2
 pkgdesc='The GNU Debugger for all gdb supported architectures (i386/arm/mips...)'
 arch=(i686 x86_64)
 url='http://www.gnu.org/software/gdb/'
@@ -31,6 +31,7 @@ build() {
     --enable-interwork \
     --with-system-readline \
     --disable-nls \
+    --disable-sim \
     --with-python=/usr/bin/python \
     --with-system-gdbinit=/etc/gdb/gdbinit
 

--- a/archlinuxcn/gdb-multiarch/lilac.yaml
+++ b/archlinuxcn/gdb-multiarch/lilac.yaml
@@ -10,3 +10,5 @@ pre_build: aur_pre_build
 post_build: aur_post_build
 
 update_on:
+  - source: manual
+    manual: 1

--- a/archlinuxcn/gdb-multiarch/lilac.yaml
+++ b/archlinuxcn/gdb-multiarch/lilac.yaml
@@ -10,5 +10,3 @@ pre_build: aur_pre_build
 post_build: aur_post_build
 
 update_on:
-  - source: aur
-    aur: gdb-multiarch


### PR DESCRIPTION
Currently the gdb's sim folder contains problematic code that cannot be compiled and linked without any error if LTO option is on. However the simulator executables are not added into the output package and have been probably obsoleted in many Linux distributions, like [Debian](https://salsa.debian.org/gdb-team/gdb/-/blob/debian/13.1-2/debian/rules?ref_type=tags#L204). To avoid failures when building the package with Archlinux's devtools, the '--disable-sim' option is added to the configuration command-line to disable these files. In addition, syncing with upstream AUR repository is temporarily disabled until the upstream no longer has this problem, but I'm not sure whether it's necessary to and how to add another sources, like the official release, to keep the package always up-to-date.