### PR TITLE
fix: 修复微信聊天信息窗口无法打开的问题

### DIFF
--- a/archlinuxcn/wine-for-wechat/wine-wechat.patch
+++ b/archlinuxcn/wine-for-wechat/wine-wechat.patch
@@ -4,7 +4,7 @@
      cs.lpszClass      = className;
      cs.dwExStyle      = exStyle;
  
-+    if (exStyle == 0x080800a0) // WeChat/WxWork shadow hwnd
++    if (exStyle == 0x080800a0 && style != 0x80000000 ) // WeChat/WxWork shadow hwnd ; fix can not open chat info
 +    {
 +        FIXME("hack %x\n", cs.dwExStyle);
 +        return NULL;


### PR DESCRIPTION
修复微信聊天信息无法打开的问题
点击聊天界面的三个点按钮或者点击顶部title无法打开聊天详情