### PR TITLE
devtools-archlinuxcn: update to 1.0.0

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -1,19 +1,43 @@
 # Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
+# Contributor: Pierre Schmitz <pierre@archlinux.de>
 
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
-pkgver=20230307
-pkgrel=2
+epoch=1
+pkgver=1.0.0
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=d54651181bc857b1839f8cbab446389c936be459
+_tag=ce9bc2df9a69efff87581b6deaa308fdba28cc36
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
 license=('GPL')
 url='https://gitlab.archlinux.org/archlinux/devtools'
-depends=('bash' 'openssh' 'subversion' 'rsync' 'arch-install-scripts'
-         'git' 'bzr' 'mercurial' 'diffutils' 'util-linux' 'awk')
-makedepends=('asciidoc')
+depends=(
+  arch-install-scripts
+  awk
+  bash
+  binutils
+  coreutils
+  diffutils
+  findutils
+  grep
+  jq
+  openssh
+  parallel
+  rsync
+  sed
+  util-linux
+
+  bzr
+  git
+  mercurial
+  subversion
+)
+makedepends=(
+  asciidoc
+  shellcheck
+)
 optdepends=('btrfs-progs: btrfs support')
 provides=("devtools=$pkgver-$pkgrel")
 conflicts=("devtools")
@@ -30,7 +54,7 @@ pkgver() {
 
 build() {
   cd ${pkgname}
-  make BUILDTOOLVER="${pkgver}-${_upstream_pkgrel}-${arch}" PREFIX=/usr
+  make BUILDTOOLVER="${epoch}:${pkgver}-${_upstream_pkgrel}-${arch}" PREFIX=/usr
 }
 
 package() {

--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -4,10 +4,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.0.0
+pkgver=1.0.1
 pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=ce9bc2df9a69efff87581b6deaa308fdba28cc36
+_tag=f075cc43b6f9ca4d22fb4ee7a69aedb51d94346c
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')


### PR DESCRIPTION
PKGBUILD is synced again from
https://gitlab.archlinux.org/archlinux/packaging/packages/devtools/

Rebase conflicts:

* Change default BUILDTOOL to devtools-archlinuxcn
* Use x86_64 mirrors for x86_64_v3

Those two commits are tested.

---

There are many [upstream commits](https://github.com/archlinux/devtools/compare/20230307...1.0.0). Most of them are related to git migration. There is one known issue: `offload-build` may fail if the server and the client has different devtools versions [1]

[1] https://gitlab.archlinux.org/archlinux/devtools/-/issues/108