### PR TITLE
[clash-verge]: fix build failure in 1.3.2

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: sukanka<su975853527 AT gmail dot com>
 pkgname=clash-verge
-pkgver=1.3.1
-pkgrel=3
+pkgver=1.3.2
+pkgrel=1
 pkgdesc="A Clash GUI based on tauri."
 arch=('x86_64' 'aarch64')
 url="https://github.com/zzzgydi/clash-verge"
@@ -14,9 +14,9 @@ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz
 "${pkgname}.desktop"
 )
 
-sha512sums=('8f44f7888617d1ae0d371da2c66d43dfc9dd79ec883b900d984f3a8a3c3385a4eb4ec31c2a48e016c05653bbd11d148f0b144c41a8e0841f3b90d5e08f909cf2'
+sha512sums=('c5d0731488aac97020f4c3d8b36f84a08cda3c6c330a068b871c2ade0a9ffee3c17f2782a4f44ca31656bc22a6a2e4ac984c99d51fca9d58f3626391ddc0a335'
             '2066dacf2e5e0135e6403cbfb825efcdf08bbcdc781407e6bb1fbb85143817b2b1abef641d20390ff7e5b3e91a509933e9eb17a64f9de7671445ac6d5363a44a')
-
+options=(!lto)
 prepare(){
 	cd $srcdir/${pkgname}-${pkgver}
 


### PR DESCRIPTION
Hello, I'm the maintainer of this package.  This pr fixes the build failure in 1.3.2 (perhaps only on archlinux)
Though I don't know the reason, it just works. (Tested locally with `archlinuxcn-x86_64-build`)
Similar issues are https://github.com/briansmith/ring/issues/1444