### PR TITLE
devtools-archlinuxcn: update to 1.0.2

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -4,10 +4,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.0.1
-pkgrel=2
+pkgver=1.0.2
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=f075cc43b6f9ca4d22fb4ee7a69aedb51d94346c
+_tag=cfb09a4d500adc1971ff71e0d212e5e36395b0c1
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')


### PR DESCRIPTION
I only do basic smoke testing by building devtools-archlinuxcn itself.

There are no rebase conflicts, and [upstream commits](https://github.com/archlinux/devtools/compare/v1.0.1...v1.0.2) look trivial.

