### PR TITLE
Update PKGBUILD

### DIFF
--- a/archlinuxcn/hyprland-nvidia/PKGBUILD
+++ b/archlinuxcn/hyprland-nvidia/PKGBUILD
@@ -38,7 +38,7 @@ depends=(
 	vulkan-validation-layers
 	xorg-xwayland
   libliftoff
-	libdisplay-info)
+	libdisplay-info-git)
 makedepends=(
 	git
 	cmake


### PR DESCRIPTION
If you use `libdisplay-info`, you may encounter the following error when running `Hyprland`:
```
Hyprland:error while loading shared libraries: libdisplay-info.so.2: cannot open shared object file
```
Upon using `pkgfile`, it was discovered that the library `libdisplay-info.so.2` is only available in `libdisplay-info-git`.

Please note that `pkgfile` is a command-line utility used in some Linux distributions to search for package files related to a specific library or executable. It helps identify which package provides a particular file or library.