### PR TITLE
devtools-archlinuxcn: update to 1.0.3

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -4,10 +4,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.0.2
-pkgrel=2
+pkgver=1.0.3
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=cfb09a4d500adc1971ff71e0d212e5e36395b0c1
+_tag=0589cd09d493bd8c80f4e2c20a80dd93a38791d5
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')


### PR DESCRIPTION
I only do basic smoke testing by building a random AUR package.

There are no rebase conflicts, and [upstream commits](https://github.com/archlinux/devtools/compare/v1.0.2...v1.0.3) look trivial.