### PR TITLE
kmonad: fix build error

### DIFF
--- a/archlinuxcn/kmonad-git/PKGBUILD
+++ b/archlinuxcn/kmonad-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Matteo Bonora <bonora.matteo@gmail.com>
 
 pkgname=kmonad-git
-pkgver=0.4.1.r345.ga22e0ba
+pkgver=0.4.1.r358.g19cccbf
 pkgrel=1
 pkgdesc="An advanced keyboard manager"
 arch=('any')
@@ -30,7 +30,7 @@ build() {
 package() {
 	cd "$srcdir/${pkgname%-git}"
 	stack install --local-bin-path="$pkgdir/usr/bin"
-	install -Dm644 "startup/${pkgname%-git}.service" -t "$pkgdir/usr/lib/systemd/system"
+	install -Dm644 "startup/${pkgname%-git}@.service" -t "$pkgdir/usr/lib/systemd/system"
 	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
 	install -Dm644 "doc/faq.md" "$pkgdir/usr/share/doc/$pkgname/faq.md"
@@ -42,3 +42,4 @@ package() {
 	  install -Dm755 "$file" -t "$pkgdir/usr/share/doc/$pkgname/keymap/template"
 	done
 }
+


### PR DESCRIPTION
Kmonad has replaced kmoand.service with kmonad@.service. This PR has updated the corresponding install script accordingly.

