### PR TITLE
qt6-base-24h, qt6-base-24hms: fix broken license symlinks

### DIFF
--- a/archlinuxcn/qt6-base-24h/PKGBUILD
+++ b/archlinuxcn/qt6-base-24h/PKGBUILD
@@ -83,6 +83,7 @@ package() {
   DESTDIR="$pkgdir" cmake --install build
 
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir"/usr/share/licenses/$pkgbase
+  ln -s /usr/share/licenses/$pkgbase "$pkgdir"/usr/share/licenses/qt6-base
 
 # Install symlinks for user-facing tools
   cd "$pkgdir"

--- a/archlinuxcn/qt6-base-24hms/PKGBUILD
+++ b/archlinuxcn/qt6-base-24hms/PKGBUILD
@@ -83,6 +83,7 @@ package() {
   DESTDIR="$pkgdir" cmake --install build
 
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir"/usr/share/licenses/$pkgbase
+  ln -s /usr/share/licenses/$pkgbase "$pkgdir"/usr/share/licenses/qt6-base
 
 # Install symlinks for user-facing tools
   cd "$pkgdir"


### PR DESCRIPTION
fix #3390