### PR TITLE
telegram-desktop-megumifox: bring back auto updates

### DIFF
--- a/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
+++ b/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
@@ -5,13 +5,10 @@ maintainers:
 build_prefix: extra-x86_64
 
 update_on:
-  - source: manual
-    manual: 4.8.4
-  # 4.8.5 requires unstable glibmm 2.77
-  # - source: github
-  #   github: telegramdesktop/tdesktop
-  #   branch: dev
-  #   use_latest_release: true
+  - source: github
+    github: telegramdesktop/tdesktop
+    branch: dev
+    use_latest_release: true
   - source: manual
     manual: 7
   - source: alpm


### PR DESCRIPTION
Now that glibmm-2.68 2.78.0-1 has landed in arch, we can follow upstream versions again.