### PR TITLE
revda-git: use cmake instead of directly invoking ninja

### DIFF
--- a/archlinuxcn/revda-git/PKGBUILD
+++ b/archlinuxcn/revda-git/PKGBUILD
@@ -45,10 +45,10 @@ build() {
     mkdir -p build
     cd build
     cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release  ..
-    ninja
+    cmake --build .
 }
 
 package() {
     cd $srcdir/Revda/build
-    DESTDIR="$pkgdir" ninja install
+    DESTDIR="$pkgdir" cmake --install .
 }

--- a/archlinuxcn/revda-git/lilac.yaml
+++ b/archlinuxcn/revda-git/lilac.yaml
@@ -11,3 +11,5 @@ update_on:
     github: THMonster/Revda
   - alias: libssl
   - alias: libcrypto
+  - source: manual
+    manual: 1


### PR DESCRIPTION
This makes it so that this package no longer owns /usr/local and /usr/local/bin

Builds fine for me in a clean chroot, also the resulting package works for me.