### PR TITLE
devtools-archlinuxcn: update to 1.0.4

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -4,10 +4,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.0.3
-pkgrel=2
+pkgver=1.0.4
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=0589cd09d493bd8c80f4e2c20a80dd93a38791d5
+_tag=ac4d056aa8254c8487ed93834a6d7e7b1e63e153
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
@@ -29,7 +29,7 @@ depends=(
   sed
   util-linux
 
-  bzr
+  breezy
   git
   mercurial
   subversion


### PR DESCRIPTION
Also replaces bzr by breezy

See: https://gitlab.archlinux.org/archlinux/packaging/packages/devtools/-/commit/50f0b46b1c31f4e478e597688ce825ad68942340
See: https://archlinux.org/todo/change-dependency-from-bzr-to-breezy/

---

I only do basic smoke testing by building devtools-archlinuxcn itself.

There are no rebase conflicts, and [upstream commits](https://github.com/archlinux/devtools/compare/v1.0.3...v1.0.4) look trivial.