### PR TITLE
telegram-desktop-megumifox: depend on libxcomposite

### DIFF
--- a/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
@@ -11,7 +11,7 @@ url="https://desktop.telegram.org/"
 license=('GPL3')
 depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal'
          'qt6-imageformats' 'qt6-svg' 'qt6-wayland' 'xxhash' 'glibmm-2.68'
-         'rnnoise' 'pipewire' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
+         'rnnoise' 'pipewire' 'libxcomposite' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
          'openssl' 'protobuf')
 makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'microsoft-gsl' 'meson'
              'extra-cmake-modules' 'wayland-protocols' 'plasma-wayland-protocols' 'libtg_owt'


### PR DESCRIPTION
The .BUILDINFO of telegram-desktop 4.10.3-2 in the official repos package seems to have 
```
installed = qt6-base-6.6.0-1-x86_64
installed = qt6-declarative-6.6.0-1-x86_64
installed = qt6-imageformats-6.5.3-1-x86_64
installed = qt6-svg-6.6.0-1-x86_64
installed = qt6-translations-6.5.3-1-any
installed = qt6-wayland-6.5.3-1-x86_64
```
While qt6-wayland 6.6.0-1 [removed](https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-wayland/-/commit/67c9415ad8ce4372b9699a14114f4729470a581e) its libxcomposite dependency which was only pulled in as a transitive dep through this qt6-wayland.

I guess that's why the official repo package builds while our builds failed...