### PR TITLE
Updated depenedncy name of latte-dock

### DIFF
--- a/archlinuxcn/latte-dock-git/PKGBUILD
+++ b/archlinuxcn/latte-dock-git/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='Latte is a dock based on plasma frameworks that provides an elegant and
 arch=('i686' 'x86_64')
 url='https://invent.kde.org/plasma/latte-dock'
 license=('GPL')
-depends=('plasma-workspace' 'plasma-framework>=5.38.0' 'knewstuff' 'hicolor-icon-theme' )
+depends=('plasma-workspace' 'plasma-framework5>=5.38.0' 'knewstuff5' 'hicolor-icon-theme' )
 makedepends=('git' 'cmake' 'extra-cmake-modules' 'appstream' 'plasma-wayland-protocols')
 optdepends=('libunity: quicklists, counters, and progress bars for apps using libunity')
 conflicts=('latte-dock')


### PR DESCRIPTION
The upstream changes the name of the plasma-framework and knewstuff:

https://archlinux.org/packages/extra/x86_64/plasma-framework5/
https://archlinux.org/packages/extra/x86_64/knewstuff5/