### PR TITLE
screengrab-git: Rename kf5 packages

### DIFF
--- a/archlinuxcn/screengrab-git/PKGBUILD
+++ b/archlinuxcn/screengrab-git/PKGBUILD
@@ -4,12 +4,12 @@
 _pkgname=screengrab
 pkgname=$_pkgname-git
 pkgver=2.6.0.15.g896ccd7
-pkgrel=1
+pkgrel=2
 pkgdesc="Crossplatform tool for grabbing screenshots of your desktop."
 arch=("i686" "x86_64")
 url="https://github.com/lxqt/screengrab"
 license=("GPL2")
-depends=("qt5-base" "qt5-x11extras" "kwindowsystem" "libqtxdg-git" "libx11" "libxcb" "hicolor-icon-theme")
+depends=("qt5-base" "qt5-x11extras" "kwindowsystem5" "libqtxdg-git" "libx11" "libxcb" "hicolor-icon-theme")
 makedepends=("git" "cmake" "qt5-tools")
 provides=("$_pkgname=$pkgver")
 conflicts=("$_pkgname")

--- a/archlinuxcn/screengrab-git/lilac.yaml
+++ b/archlinuxcn/screengrab-git/lilac.yaml
@@ -2,12 +2,12 @@
 
 maintainers:
 - github: ykelvis
+
 pre_build_script: |
-  vcs_update()
+  aur_pre_build(maintainers=['yan12125'])
 
 post_build_script: |
-  git_pkgbuild_commit()
-  update_aur_repo()
+  aur_post_build()
 
 repo_depends:
 - libqtxdg-git
@@ -15,3 +15,5 @@ repo_depends:
 update_on:
 - source: github
   github: lxqt/screengrab
+- source: aur
+  aur: screengrab-git


### PR DESCRIPTION
I maintain https://aur.archlinux.org/packages/screengrab-git but not this package, so syncing PKGBUILD is not trivial. This time, I update both manually.