### PR TITLE
hysteria: 2.1.0 -> 2.1.1

### DIFF
--- a/archlinuxcn/hysteria/PKGBUILD
+++ b/archlinuxcn/hysteria/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgbase=hysteria
 pkgname=$_pkgbase
-pkgver=2.1.0
+pkgver=2.1.1
 pkgrel=1
 pkgdesc='A powerful, lightning fast and censorship resistant proxy'
 arch=('x86_64')


### PR DESCRIPTION
Diff: https://github.com/apernet/hysteria/compare/app/v2.1.0...app/v2.1.1

Changelog: https://github.com/apernet/hysteria/releases/tag/app%2Fv2.1.1

Fix #3513

```
$ namcap PKGBUILD
$ namcap hysteria-2.1.1-1-x86_64.pkg.tar.zst 
hysteria W: Directory (etc/hysteria) is empty
hysteria W: Dependency included, but may not be needed ('acl')
hysteria W: Dependency included, but may not be needed ('shadow')
```
