### PR TITLE
nali-go: fix unknown version error

### DIFF
--- a/archlinuxcn/nali-go/PKGBUILD
+++ b/archlinuxcn/nali-go/PKGBUILD
@@ -1,39 +1,40 @@
 # Maintainer: Coelacanthus <CoelacanthusHex@gmail.com>
+# Contributor: DCjanus <DCjanus@dcjanus.com>
 
 pkgname=nali-go
+_pkgname=nali
 pkgver=0.8.0
 pkgrel=1
 pkgdesc='An offline tool for querying IP geographic information and CDN provider.'
-arch=('x86_64')
+arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv7h' 'armv6h' 'aarch64')
 url="https://github.com/zu1k/nali"
 license=('MIT')
-conflicts=('nali-cli')
-makedepends=('go')
+makedepends=("go>=1.18")
+provides=('nali')
+conflicts=('nali-cli' 'nali')
 source=("$pkgname-$pkgver::https://github.com/zu1k/nali/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('837b096de0278ee2a539357a0cd1c56e827c1bbd53be5822df5404b007ce12f2')
 b2sums=('85c000c836e6c7b62cfd55372fa70db985765b3fbbc606b3edb412e14dea54e5f3a4ad6f7bf202deabc5f13a8e30f77c84a92dcab327fd0793d7a3cc27abfb82')
-# Golang no support
-options=(!lto)
 
 build() {
-    cd "$srcdir/nali-$pkgver"
-    go build \
-        -buildmode=pie \
-        -mod=readonly \
-        -modcacherw \
-        -ldflags "-compressdwarf=false -linkmode external -X \"github.com/zu1k/nali/constant.Version=$pkgver\" -extldflags $LDFLAGS" \
-        -o $pkgname .
+  cd "$srcdir/$_pkgname-$pkgver"
+  go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-compressdwarf=false -linkmode external -X \"github.com/zu1k/nali/internal/constant.Version=$pkgver\" -extldflags $LDFLAGS" \
+    -o $_pkgname .
 }
 
 package() {
-    cd "$srcdir/nali-$pkgver"
-    install -Dm755 $pkgname "$pkgdir"/usr/bin/$pkgname
-    ln -sf ./$pkgname "$pkgdir"/usr/bin/nali
-    mkdir -p "$pkgdir/usr/share/bash-completion/completions/"
-    ./$pkgname completion bash > "$pkgdir/usr/share/bash-completion/completions/nali"
-    mkdir -p "$pkgdir/usr/share/zsh/site-functions/"
-    ./$pkgname completion zsh > "$pkgdir/usr/share/zsh/site-functions/_nali"
-    mkdir -p "$pkgdir/usr/share/fish/completions/"
-    ./$pkgname completion fish > "$pkgdir/usr/share/fish/completions/nali.fish"
-    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  cd "$srcdir/$_pkgname-$pkgver"
+  install -Dm755 $_pkgname "$pkgdir"/usr/bin/$_pkgname
+  mkdir -p "$pkgdir/usr/share/bash-completion/completions/"
+  ./$_pkgname completion bash > "$pkgdir/usr/share/bash-completion/completions/nali"
+  mkdir -p "$pkgdir/usr/share/zsh/site-functions/"
+  ./$_pkgname completion zsh > "$pkgdir/usr/share/zsh/site-functions/_nali"
+  mkdir -p "$pkgdir/usr/share/fish/completions/"
+  ./$_pkgname completion fish > "$pkgdir/usr/share/fish/completions/nali.fish"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
 }

--- a/archlinuxcn/nali-go/PKGBUILD
+++ b/archlinuxcn/nali-go/PKGBUILD
@@ -1,40 +1,39 @@
 # Maintainer: Coelacanthus <CoelacanthusHex@gmail.com>
-# Contributor: DCjanus <DCjanus@dcjanus.com>
 
 pkgname=nali-go
-_pkgname=nali
 pkgver=0.8.0
 pkgrel=1
 pkgdesc='An offline tool for querying IP geographic information and CDN provider.'
-arch=('i686' 'pentium4' 'x86_64' 'arm' 'armv7h' 'armv6h' 'aarch64')
+arch=('x86_64')
 url="https://github.com/zu1k/nali"
 license=('MIT')
-makedepends=("go>=1.18")
-provides=('nali')
-conflicts=('nali-cli' 'nali')
+conflicts=('nali-cli')
+makedepends=('go')
 source=("$pkgname-$pkgver::https://github.com/zu1k/nali/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('837b096de0278ee2a539357a0cd1c56e827c1bbd53be5822df5404b007ce12f2')
 b2sums=('85c000c836e6c7b62cfd55372fa70db985765b3fbbc606b3edb412e14dea54e5f3a4ad6f7bf202deabc5f13a8e30f77c84a92dcab327fd0793d7a3cc27abfb82')
+# Golang no support
+options=(!lto)
 
 build() {
-  cd "$srcdir/$_pkgname-$pkgver"
-  go build \
-    -trimpath \
-    -buildmode=pie \
-    -mod=readonly \
-    -modcacherw \
-    -ldflags "-compressdwarf=false -linkmode external -X \"github.com/zu1k/nali/internal/constant.Version=$pkgver\" -extldflags $LDFLAGS" \
-    -o $_pkgname .
+    cd "$srcdir/nali-$pkgver"
+    go build \
+        -buildmode=pie \
+        -mod=readonly \
+        -modcacherw \
+        -ldflags "-compressdwarf=false -linkmode external -X \"github.com/zu1k/nali/internal/constant.Version=$pkgver\" -extldflags $LDFLAGS" \
+        -o $pkgname .
 }
 
 package() {
-  cd "$srcdir/$_pkgname-$pkgver"
-  install -Dm755 $_pkgname "$pkgdir"/usr/bin/$_pkgname
-  mkdir -p "$pkgdir/usr/share/bash-completion/completions/"
-  ./$_pkgname completion bash > "$pkgdir/usr/share/bash-completion/completions/nali"
-  mkdir -p "$pkgdir/usr/share/zsh/site-functions/"
-  ./$_pkgname completion zsh > "$pkgdir/usr/share/zsh/site-functions/_nali"
-  mkdir -p "$pkgdir/usr/share/fish/completions/"
-  ./$_pkgname completion fish > "$pkgdir/usr/share/fish/completions/nali.fish"
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+    cd "$srcdir/nali-$pkgver"
+    install -Dm755 $pkgname "$pkgdir"/usr/bin/$pkgname
+    ln -sf ./$pkgname "$pkgdir"/usr/bin/nali
+    mkdir -p "$pkgdir/usr/share/bash-completion/completions/"
+    ./$pkgname completion bash > "$pkgdir/usr/share/bash-completion/completions/nali"
+    mkdir -p "$pkgdir/usr/share/zsh/site-functions/"
+    ./$pkgname completion zsh > "$pkgdir/usr/share/zsh/site-functions/_nali"
+    mkdir -p "$pkgdir/usr/share/fish/completions/"
+    ./$pkgname completion fish > "$pkgdir/usr/share/fish/completions/nali.fish"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
使用从 archlinuxcn 安装的 nali-go 时，发现执行 `nali --version` 后，输出为 `nali version unknown version`。

查看代码后，认为原因是：nali-go 依赖编译时的 `-ldflags -X` 参数注入版本信息，上游代码中 Version 变量的导入路径发生过变化，导致 archlinuxcn 仓库中 PKGBUILD 产出的二进制没有正确的版本信息。

```diff
- github.com/zu1k/nali/constant.Version
+ github.com/zu1k/nali/internal/constant.Version
```

另外对比 AUR 中 nali-go 的 PKGBUILD，同步了一些变更到 archlinuxcn repo 中。

不是很熟悉 PKGBUILD，希望不要引入更多预期外问题，设置了 `Allow edits by maintainers`，有什么想法也可以直接修改这个 PR 的内容。

PS:

+ 我参考的 PKGBUILD: <https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=nali-go&id=c142319c85e4a0fab5cc0e85de9fd064750fc2e2>