### PR TITLE
Clash verge: change upstream and update to 1.3.9

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: sukanka<su975853527 AT gmail dot com>
 pkgname=clash-verge
-pkgver=1.3.8
-pkgrel=2
-pkgdesc="A Clash GUI based on tauri."
+pkgver=1.3.9
+pkgrel=1
+pkgdesc="A Clash GUI based on tauri, MetaCubeX's fork."
 arch=('x86_64' 'aarch64')
-url="https://github.com/zzzgydi/clash-verge"
+url="https://github.com/MetaCubeX/clash-verge"
 license=('GPL3')
 depends=('webkit2gtk' 'clash-geoip' 'libayatana-appindicator')
 makedepends=('yarn' 'cargo-tauri' 'clash-premium-bin' 'clash-meta'  'jq' 'moreutils' 'rust' 'quickjs')
@@ -14,7 +14,7 @@ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz
 "${pkgname}.desktop"
 )
 
-sha512sums=('9f817949907a59c00fc865007dc01cc5f48ac6d28539f0c861159f84cb141b92c482c80ad62ae79bfc2afea5162b9be797b1bd3751f3227ddecc2fc6b505326b'
+sha512sums=('914f557c2eabd083a1ef8e5dcb7ded576f1ab3a41a1b7bf8c4f3a3a9109b4a284a80166a3dfaa74a5846785c721522c6b5edd31d34da1a4f9f8022bcd9377cf5'
             '2066dacf2e5e0135e6403cbfb825efcdf08bbcdc781407e6bb1fbb85143817b2b1abef641d20390ff7e5b3e91a509933e9eb17a64f9de7671445ac6d5363a44a')
 options=(!lto)
 prepare(){

--- a/archlinuxcn/clash-verge/lilac.yaml
+++ b/archlinuxcn/clash-verge/lilac.yaml
@@ -18,7 +18,7 @@ repo_depends:
 
 update_on:
   - source: github
-    github: zzzgydi/clash-verge
+    github: MetaCubeX/clash-verge
     use_latest_release: true
     prefix: v
   - source: aur


### PR DESCRIPTION
clash-verge [原始仓库](https://github.com/zzzgydi/clash-verge)归档了，先切换到 [MetaCubeX](https://github.com/MetaCubeX/clash-verge) 的 fork， 并更新到 1.3.9 版本。