### PR TITLE
nheko-git: Remove COMPILE_QML from cmake options

### DIFF
--- a/archlinuxcn/nheko-git/PKGBUILD
+++ b/archlinuxcn/nheko-git/PKGBUILD
@@ -45,8 +45,7 @@ build() {
   cmake .. -DHUNTER_ENABLED=OFF \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=None \
-        -DCOMPILE_QML=On
+        -DCMAKE_BUILD_TYPE=None
   make
 }
 


### PR DESCRIPTION
Upstream [removed](https://github.com/Nheko-Reborn/nheko/commit/87c063b112b8c7dc1a858af8406008da48b5260b) this option as Qt6 does AOT for qml by default.