### PR TITLE
rime-sbxlm: update sbxlm init script

### DIFF
--- a/archlinuxcn/rime-sbxlm/sbxlm-init
+++ b/archlinuxcn/rime-sbxlm/sbxlm-init
@@ -8,3 +8,4 @@ mkdir -p $RIME_DIR
 for f in /usr/share/sbxlm/init-userdb/*.tar.gz;do
   tar xf $f --directory="$RIME_DIR"
 done
+cp /usr/share/rime-data/default.custom.yaml $RIME_DIR


### PR DESCRIPTION
rime 默认使用逗号、句号分页，但是声笔系列码使用这两个按键提交上屏，所以在初始化声笔系列用户配置的时候，需要把声笔系列码的 default.custom.yaml 复制到用户的配置目录。