### PR TITLE
nheko-git: Use SPDX license identifier and remove lilac throttle

### DIFF
--- a/archlinuxcn/nheko-git/PKGBUILD
+++ b/archlinuxcn/nheko-git/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Desktop client for the Matrix protocol"
 arch=(armv7h aarch64 i686 x86_64)
 
 url="https://github.com/Nheko-Reborn/nheko"
-license=("GPL3")
+license=("GPL-3.0-or-later")
 
 depends=(
   lmdb qt6-base qt6-svg qt6-multimedia qt6-declarative

--- a/archlinuxcn/nheko-git/lilac.yaml
+++ b/archlinuxcn/nheko-git/lilac.yaml
@@ -8,7 +8,6 @@ repo_depends:
 
 update_on:
   - source: vcs
-    lilac_throttle: 3d
   - source: alpm
     from_pattern: ^(.*)
     to_pattern: \1


### PR DESCRIPTION
Newer versions of namcap seem to have started to output errors for the legacy license notation.

Also building this takes only ~2mins on the build machine, I don't think such a long throttle is needed...