### PR TITLE
xone-dkms-git: fix missing source files

### DIFF
--- a/archlinuxcn/xone-dkms-git/PKGBUILD
+++ b/archlinuxcn/xone-dkms-git/PKGBUILD
@@ -34,7 +34,7 @@ package() {
 
   echo "* Copying module into /usr/src..."
   install -dm755 "${pkgdir}/usr/src/${_pkgname}-${pkgver}"
-  cp -r ${srcdir}/$_pkgname/{bus,driver,transport,Kbuild,dkms.conf} "${pkgdir}/usr/src/${_pkgname}-${pkgver}"
+  cp -r ${srcdir}/$_pkgname/{auth,bus,driver,transport,Kbuild,dkms.conf} "${pkgdir}/usr/src/${_pkgname}-${pkgver}"
 
   echo "* Blacklisting xpad module..."
   install -D -m 644 install/modprobe.conf "${pkgdir}/etc/modprobe.d/xone-blacklist.conf"


### PR DESCRIPTION
Upstream introduced a new directory (`auth/`) that are left out by our package(). Let's fix just that.