### PR TITLE
telegram-desktop-{lily,megumifox}: Rebuild on libvpx soname bump

### DIFF
--- a/archlinuxcn/telegram-desktop-lily/lilac.yaml
+++ b/archlinuxcn/telegram-desktop-lily/lilac.yaml
@@ -18,3 +18,6 @@ update_on:
   - source: alpm
     alpm: abseil-cpp
     strip_release: true
+  - source: alpm
+    alpm: libvpx
+    provided: libvpx.so

--- a/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
+++ b/archlinuxcn/telegram-desktop-megumifox/lilac.yaml
@@ -23,3 +23,6 @@ update_on:
   - source: alpm
     alpm: abseil-cpp
     strip_release: true
+  - source: alpm
+    alpm: libvpx
+    provided: libvpx.so


### PR DESCRIPTION
`readelf -d /usr/bin/telegram-desktop` contains libvpx.so.8 so it's a direct dependency.

The PKGBUILD should also probably be modified to include libvpx as a dependecy...