### PR TITLE
fix(nekoray): update optdepends package names

### DIFF
--- a/archlinuxcn/nekoray/PKGBUILD
+++ b/archlinuxcn/nekoray/PKGBUILD
@@ -16,8 +16,8 @@ optdepends=(
     'v2ray-domain-list-community: geosite data for NekoRay'
     'v2ray-geoip: geoip data for NekoRay'
     # AUR
-    'sing-geoip: geoip data for NekoBox'
-    'sing-geosite: geosite data for NekoBox'
+    'sing-geoip-db: geoip data for NekoBox'
+    'sing-geosite-db: geosite data for NekoBox'
 )
 
 source=(


### PR DESCRIPTION
These AUR packages have renamed to [sing-geoip-db](https://aur.archlinux.org/packages/sing-geoip-db) and [sing-geosite-db](https://aur.archlinux.org/packages/sing-geosite-db).