### PR TITLE
video-trimmer: fix lilac.yaml

### DIFF
--- a/archlinuxcn/video-trimmer/lilac.yaml
+++ b/archlinuxcn/video-trimmer/lilac.yaml
@@ -13,5 +13,5 @@ update_on:
   - source: gitlab
     gitlab: YaLTeR/video-trimmer
     host: gitlab.gnome.org
-    use_latest_release: true
+    use_latest_tag: true
     prefix: v


### PR DESCRIPTION
Sorry for having made a mistake of release/tag
URL: YaLTeR/video-trimmer/-/releases/v0.8.2
the "v0.8.2" is tag