### PR TITLE
wiliwili: fix build error caused by missing `libxinerama` at makedepends

### DIFF
--- a/archlinuxcn/wiliwili/PKGBUILD
+++ b/archlinuxcn/wiliwili/PKGBUILD
@@ -10,32 +10,35 @@ pkgdesc='专为手柄控制设计的第三方跨平台B站客户端'
 arch=('x86_64' 'aarch64')
 url='https://github.com/xfangfang/wiliwili'
 license=('GPL-3.0-or-later')
-depends=('mpv' 'opencc' 'pystring')
-makedepends=('cmake' 'git' 'libxi' 'ninja' 'python' 'wayland-protocols')
+depends=('curl' 'dbus' 'gcc-libs' 'glibc' 'hicolor-icon-theme' 'libwebp' 'mpv' 'opencc' 'openssl' 'pystring' 'tinyxml2' 'zlib')
+makedepends=('cmake' 'git' 'libxi' 'libxinerama' 'ninja' 'python' 'wayland-protocols')
 source=("${pkgname}"::"git+${url}.git#tag=v${pkgver}")
-sha512sums=('SKIP')
+b2sums=('SKIP')
 
 prepare() {
   git -C "${srcdir}/${pkgname}" submodule update --init --recursive
-}
 
-build() {
   cmake \
-    -S "${srcdir}/${pkgname}" \
     -B "${srcdir}/build" \
-    -G Ninja \
     -D CMAKE_BUILD_TYPE=Release \
     -D CMAKE_INSTALL_PREFIX='/usr' \
     -D INSTALL=ON \
     -D PLATFORM_DESKTOP=ON \
     -D USE_SYSTEM_CURL=ON \
-    -D USE_SYSTEM_OPENCC=ON \
     -D USE_SYSTEM_PYSTRING=ON \
-    -D USE_SYSTEM_SDL2=ON
+    -D USE_SYSTEM_OPENCC=ON \
+    -D USE_SYSTEM_TINYXML2=ON \
+    -D USE_SYSTEM_SDL2=ON \
+    -D GLFW_BUILD_WAYLAND=ON \
+    -D GLFW_BUILD_X11=ON \
+    -G Ninja \
+    -S "${srcdir}/${pkgname}"
+}
 
-  ninja -C "${srcdir}/build" wiliwili
+build() {
+  cmake --build "${srcdir}/build"
 }
 
 package() {
-  DESTDIR="${pkgdir}" ninja -C "${srcdir}/build" install
+  DESTDIR="${pkgdir}" cmake --install "${srcdir}/build"
 }

--- a/archlinuxcn/wiliwili/lilac.yaml
+++ b/archlinuxcn/wiliwili/lilac.yaml
@@ -15,3 +15,5 @@ update_on:
     github: xfangfang/wiliwili
     use_max_tag: true
     prefix: v
+  - source: manual
+    manual: 1


### PR DESCRIPTION
Also dynamically linked to [tinyxml2](https://archlinux.org/packages/extra/x86_64/tinyxml2/)