### PR TITLE
video-trimmer: fix lilac.yaml

### DIFF
--- a/archlinuxcn/video-trimmer/lilac.yaml
+++ b/archlinuxcn/video-trimmer/lilac.yaml
@@ -13,5 +13,5 @@ update_on:
   - source: gitlab
     gitlab: YaLTeR/video-trimmer
     host: gitlab.gnome.org
-    use_latest_tag: true
+    use_max_tag: true
     prefix: v


### PR DESCRIPTION
change  "use_latest_tag" to "use_max_tag"