### PR TITLE
paru{,-git}: rebuild on libalpm.so

### DIFF
--- a/archlinuxcn/paru-git/lilac.yaml
+++ b/archlinuxcn/paru-git/lilac.yaml
@@ -8,3 +8,6 @@ update_on:
     github: Morganamilo/paru
   - alias: libssl
   - alias: libcrypto
+  - source: alpm
+    alpm: pacman
+    provided: libalpm.so

--- a/archlinuxcn/paru/lilac.yaml
+++ b/archlinuxcn/paru/lilac.yaml
@@ -10,3 +10,6 @@ update_on:
   - source: github
     github: Morganamilo/paru
     use_latest_release: true
+  - source: alpm
+    alpm: pacman
+    provided: libalpm.so


### PR DESCRIPTION
Paru 2.0.3 already builds w/ pacman 6.1, so just trigger a rebuild.