### PR TITLE
yay-git: rebuild on libalpm.so

### DIFF
--- a/archlinuxcn/yay-git/lilac.yaml
+++ b/archlinuxcn/yay-git/lilac.yaml
@@ -12,3 +12,6 @@ update_on:
   - source: github
     github: Jguer/yay
     branch: next
+  - source: alpm
+    alpm: pacman
+    provided: libalpm.so


### PR DESCRIPTION
Same as #3697, but for yay-git.

The yay package has update_on aur, and the maintainer of the corresponding aur package seems to bump the pkgrel on pacman updates, so we can maybe get away with not adding this there.