### PR TITLE
fix 64gram

### DIFF
--- a/archlinuxcn/64gram-desktop/lilac.yaml
+++ b/archlinuxcn/64gram-desktop/lilac.yaml
@@ -22,6 +22,9 @@ update_on:
   - source: alpm
     alpm: libvpx
     provided: libvpx.so
+  - source: alpm
+    alpm: abseil-cpp
+    provided: libabsl_strings.so
   - source: manual
     manual: 1.0.3
 


### PR DESCRIPTION
```64gram-desktop: error while loading shared libraries: libabsl_strings.so.2308.0.0: cannot open shared object file: No such file or directory```
