### PR TITLE
Update lilac.yaml

### DIFF
--- a/archlinuxcn/64gram-desktop/lilac.yaml
+++ b/archlinuxcn/64gram-desktop/lilac.yaml
@@ -24,7 +24,7 @@ update_on:
     provided: libvpx.so
   - source: alpm
     alpm: abseil-cpp
-    provided: libabsl_strings.so
+    strip_release: true
   - source: manual
     manual: 1.0.3
 


### PR DESCRIPTION
fix by

https://github.com/archlinuxcn/repo/blob/6841d8b3645b26f3404e7b9df5f1b99668c3a78e/archlinuxcn/telegram-desktop-megumifox/lilac.yaml#L23-L25

```json
{
  "logger_name": "nvchecker.core",
  "name": "64gram-desktop:7",
  "event": "provides element not found",
  "level": "error"
}
```
