### PR TITLE
amberol: Add package

### DIFF
--- a/archlinuxcn/amberol/PKGBUILD
+++ b/archlinuxcn/amberol/PKGBUILD
@@ -5,54 +5,50 @@ pkgname=amberol
 pkgver=0.10.3
 pkgrel=1
 pkgdesc="Plays music, and nothing else"
-arch=('x86_64' 'aarch64')
-url="https://apps.gnome.org/app/io.bassi.Amberol"
+arch=(x86_64)
+url="https://gitlab.gnome.org/World/amberol"
 license=('GPL-3.0-or-later')
-depends=('libadwaita'
-         'gstreamer' 
-         'gcc-libs'
-         'gdk-pixbuf2'
-         'dbus'
-         'hicolor-icon-theme'
-         'dconf'
-         'glibc'
-         'pango'
-         'glib2'
-         'cairo'
-         'graphene'
-         'gtk4'
-         'gst-plugins-base-libs'
-         'gst-plugins-bad-libs')
-makedepends=('meson'
-             'cargo')
-checkdepends=('appstream-glib'
-              'reuse')
-source=("https://gitlab.gnome.org/World/amberol/-/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+depends=(cairo
+         dbus
+         dconf
+         gcc-libs
+         gdk-pixbuf2
+         glib2
+         glibc
+         graphene
+         gst-plugins-bad-libs
+         gst-plugins-base-libs
+         gstreamer
+         gtk4
+         hicolor-icon-theme
+         libadwaita
+         pango)
+makedepends=(cargo
+             meson)
+checkdepends=(appstream-glib
+              desktop-file-utils
+              reuse)
+_archive="$pkgname-$pkgver"
+source=("$_archive.tar.gz::$url/-/archive/$pkgver/$_archive.tar.gz")
 options=('!lto')
-sha512sums=("12684a222e06d0abbab03f6196021c262416ca9ed48526dd5343432a314c2615866ad6b97032c45d93003bb198a2bc90cb23baaf7debe3d3581cb3fd925021cf")
+sha512sums=('12684a222e06d0abbab03f6196021c262416ca9ed48526dd5343432a314c2615866ad6b97032c45d93003bb198a2bc90cb23baaf7debe3d3581cb3fd925021cf')
 
 prepare() {
-  cd ${pkgname}-${pkgver}
+  cd $_archive
   export RUSTUP_TOOLCHAIN=stable
   cargo update
   cargo fetch --target "$CARCH-unknown-linux-gnu"
 }
 
 build() {
-  local meson_options=(
-    --buildtype release
-  )
-
-  export RUSTUP_TOOLCHAIN=stable
-  arch-meson ${pkgname}-${pkgver} build "${meson_options[@]}"
+  arch-meson $_archive build --buildtype=release
   meson compile -C build
 }
 
 check() {
-  meson test -C build --print-errorlogs || :
+  meson test -C build --print-errorlogs
 }
 
 package() {
   meson install -C build --destdir "$pkgdir"
 }
-

--- a/archlinuxcn/amberol/PKGBUILD
+++ b/archlinuxcn/amberol/PKGBUILD
@@ -23,8 +23,7 @@ depends=('libadwaita'
          'gtk4'
          'gst-plugins-base-libs'
          'gst-plugins-bad-libs')
-makedepends=('git'
-             'meson'
+makedepends=('meson'
              'cargo')
 checkdepends=('appstream-glib'
               'reuse')

--- a/archlinuxcn/amberol/PKGBUILD
+++ b/archlinuxcn/amberol/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Kiri <kiri@vern.cc> 
+# Contributor: Igor Dyatlov <dyatlov.igor@protonmail.com>
+
+pkgname=amberol
+pkgver=0.10.3
+pkgrel=1
+pkgdesc="Plays music, and nothing else"
+arch=('x86_64' 'aarch64')
+url="https://apps.gnome.org/app/io.bassi.Amberol"
+license=('GPL-3.0-or-later')
+depends=('libadwaita'
+         'gstreamer' 
+         'gcc-libs'
+         'gdk-pixbuf2'
+         'dbus'
+         'hicolor-icon-theme'
+         'dconf'
+         'glibc'
+         'pango'
+         'glib2'
+         'cairo'
+         'graphene'
+         'gtk4'
+         'gst-plugins-base-libs'
+         'gst-plugins-bad-libs')
+makedepends=('git'
+             'meson'
+             'cargo')
+checkdepends=('appstream-glib'
+              'reuse')
+source=("https://gitlab.gnome.org/World/amberol/-/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+options=('!lto')
+sha512sums=("12684a222e06d0abbab03f6196021c262416ca9ed48526dd5343432a314c2615866ad6b97032c45d93003bb198a2bc90cb23baaf7debe3d3581cb3fd925021cf")
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  export RUSTUP_TOOLCHAIN=stable
+  cargo update
+  cargo fetch --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  local meson_options=(
+    --buildtype release
+  )
+
+  export RUSTUP_TOOLCHAIN=stable
+  arch-meson ${pkgname}-${pkgver} build "${meson_options[@]}"
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs || :
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+}
+

--- a/archlinuxcn/amberol/lilac.yaml
+++ b/archlinuxcn/amberol/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: gitlab
+    gitlab: World/amberol
+    host: gitlab.gnome.org
+    use_max_tag: true


### PR DESCRIPTION
PKGBUILD: tested by archlinuxcn-x86_64-build
```
cat amberol-0.10.3-1-x86_64.pkg.tar.zst-namcap.log:
amberol W: ELF file ('usr/bin/amberol') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
amberol W: Unused shared library '/usr/lib/libgstvideo-1.0.so.0' by file ('usr/bin/amberol')
amberol W: Unused shared library '/usr/lib/libpango-1.0.so.0' by file ('usr/bin/amberol')
amberol W: Unused shared library '/usr/lib/libcairo.so.2' by file ('usr/bin/amberol')
```

lilac.yaml: tested locally successfully, got the right pkgverl:
```
[D 03-24 23:39:27.053 worker:214] got input: {'depend_packages': [], 'update_info': [[None, '0.10.3']],
```


