### PR TITLE
feat: update AUR repo when `sing-geoip` and `sing-geosite` are updated

### DIFF
--- a/archlinuxcn/sing-geoip/lilac.yaml
+++ b/archlinuxcn/sing-geoip/lilac.yaml
@@ -1,8 +1,11 @@
 maintainers:
   - github: Integral-Tech
+  - github: everyx
 
 pre_build_script: update_pkgver_and_pkgrel(_G.newver)
-post_build_script: git_pkgbuild_commit()
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
 
 update_on:
   - source: github

--- a/archlinuxcn/sing-geosite/lilac.yaml
+++ b/archlinuxcn/sing-geosite/lilac.yaml
@@ -1,8 +1,11 @@
 maintainers:
   - github: Integral-Tech
+  - github: everyx
 
 pre_build_script: update_pkgver_and_pkgrel(_G.newver)
-post_build_script: git_pkgbuild_commit()
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
 
 update_on:
   - source: github


### PR DESCRIPTION
我是 AUR [`sing-geoip`](https://aur.archlinux.org/pkgbase/sing-geoip) 和 [`sing-geosite`](https://aur.archlinux.org/pkgbase/sing-geosite) 的维护者，现在是想能让 CN 的这两个包和 AUR 中的同步更新