### PR TITLE
lx-music: Add music

### DIFF
--- a/archlinuxcn/lx-music/PKGBUILD
+++ b/archlinuxcn/lx-music/PKGBUILD
@@ -1,0 +1,78 @@
+# Maintainer: Sukanka <su975853527 [AT] gmail.com>
+# Contributor: Luis Martinez <luis dot martinez at disroot dot org>
+# Contributer: Bruce Zhang
+
+pkgname=lx-music
+pkgver=2.6.0
+pkgrel=1
+_electron=electron25 
+pkgdesc='An Electron-based music player'
+arch=('x86_64' 'aarch64')
+url='https://github.com/lyswhut/lx-music-desktop'
+license=('Apache-2.0')
+depends=("${_electron}"
+	 "sh"
+         "glibc"
+         "gcc-libs"
+         "hicolor-icon-theme")
+makedepends=('asar'
+             'npm'
+             'nodejs'
+             'git'
+             'node-gyp'
+             'jq'
+             'moreutils')
+source=("$pkgname-$pkgver.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        "$pkgname.sh"
+        "$pkgname.desktop"
+        "dev-app-update.yml")
+sha256sums=('75094652cd1071e17e9be72c70a4b8a22d946213cda6079eeef7eee637668ba1'
+            '1171a3688a136b75aa0493d5737cfb1e8c386a48030c8ca313d4cac48c0630e3'
+            '732e98dfe569768c3cc90abbe8b1f6d24726dd2cb61317f57f8d5fe77fdefe2f'
+            'ffdd88036d10eb9780c0a26987894708720c2f486247bb3854f05fb5dd607423')
+
+prepare() {
+	cd "${srcdir}/${pkgname}-desktop-${pkgver}"
+	# electron from archlinux official repo does not work, skip patching.
+
+	local electronDist="/usr/lib/${_electron}"
+	local electronVersion="$(< $electronDist/version)"
+	# electronVersion="${electronVersion%.*}.0"
+	jq ".devDependencies.electron = \"$electronVersion\"" package.json | sponge package.json
+	jq ".build.electronDist = \"$electronDist\"" package.json | sponge package.json
+	jq ".build.electronVersion = \"$electronVersion\"" package.json | sponge package.json
+
+	sed -i "s|__ELECTRON__|${_electron}|g" "${srcdir}/${pkgname}.sh"
+
+}
+
+build() {
+	cd "$srcdir/$pkgname-desktop-$pkgver"
+	export HOME=${srcdir}
+	npm install
+	npm run pack:dir
+}
+
+package() {
+    install -Dm644 'dev-app-update.yml' -t  "$pkgdir/usr/lib/lx-music/"
+	install -Dm755 lx-music.sh "$pkgdir/usr/bin/lx-music"
+	install -Dm644 lx-music.desktop -t "$pkgdir/usr/share/applications/"
+
+	# Install app
+	cd "$srcdir/$pkgname-desktop-$pkgver/"
+	asar e build/linux-unpacked/resources/app.asar "$pkgdir/usr/lib/lx-music/"
+
+	# Install icons
+	install -Dm644 resources/icons/512x512.png "$pkgdir/usr/share/icons/hicolor/512x512/apps/lx-music.png"
+
+	# Install license
+	install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/lx-music/"
+	cp -a --no-preserve=ownership licenses "$pkgdir/usr/share/licenses/lx-music/"
+
+	# clean other platform.
+	for native in {bufferutil,utf-8-validate};
+	do
+		cd ${pkgdir}/usr/lib/lx-music/node_modules/$native/prebuilds
+		rm -rf darwin-* win32-*
+	done;
+}

--- a/archlinuxcn/lx-music/dev-app-update.yml
+++ b/archlinuxcn/lx-music/dev-app-update.yml
@@ -1,0 +1,6 @@
+provider: github 
+owner: lyswhut
+repo: lx-music-desktop
+repository: 
+    - type: git
+    - url: git+https://github.com/lyswhut/lx-music-desktop.git

--- a/archlinuxcn/lx-music/lilac.yaml
+++ b/archlinuxcn/lx-music/lilac.yaml
@@ -1,0 +1,18 @@
+maintainers:
+  - github: kiri2002
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+repo_depends:
+  - electron25-bin
+
+update_on:
+  - source: github
+    github: lyswhut/lx-music-desktop
+    use_max_tag: true

--- a/archlinuxcn/lx-music/lx-music.desktop
+++ b/archlinuxcn/lx-music/lx-music.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=LX Music
+Type=Application
+Name[zh_CN]=洛雪音乐助手
+Comment="An Electron-based music player"
+Comment[zh_CN]=洛雪音乐助手，一个基于 Electron 的音乐软件
+Exec=lx-music
+Terminal=false
+Icon=lx-music
+StartupWMClass=lx-music-desktop
+Categories=AudioVideo;Utility;Music

--- a/archlinuxcn/lx-music/lx-music.sh
+++ b/archlinuxcn/lx-music/lx-music.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+# Allow users to override command-line options
+if [[ -f $XDG_CONFIG_HOME/lx-music-flags.conf ]]; then
+   LX_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/lx-music-flags.conf | tr '\n' ' ')"
+fi
+
+# DO NOT change __ELECTRON__, it's updated by PKGBUILD
+exec __ELECTRON__ /usr/lib/lx-music/ "$@" $LX_USER_FLAGS


### PR DESCRIPTION
tested in extra-x86-64 with electron25-bin
```
cat electron25-bin-25.9.8-1-x86_64.pkg.tar.zst-namcap.log
electron25-bin W: ELF file ('usr/lib/electron25/chrome-sandbox') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/chrome_crashpad_handler') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/chromedriver') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/electron') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/libEGL.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/libGLESv2.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/libffmpeg.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/libvk_swiftshader.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin W: ELF file ('usr/lib/electron25/libvulkan.so.1') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
electron25-bin E: custom is not a valid SPDX license identifier. See https://spdx.org/licenses/ for valid identifiers, or prefix the identifier with 'LicenseRef-', if it is custom.
electron25-bin W: File (usr/lib/electron25/chrome-sandbox) is setuid or setgid.
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/chrome-sandbox')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/chrome_crashpad_handler')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/chrome_crashpad_handler')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/chromedriver')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/chromedriver')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/electron')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/electron')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/libEGL.so')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/libEGL.so')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/libGLESv2.so')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/libGLESv2.so')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/libffmpeg.so')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/libvk_swiftshader.so')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/libvk_swiftshader.so')
electron25-bin W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/electron25/libvulkan.so.1')
electron25-bin W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/electron25/libvulkan.so.1')
```