### PR TITLE
clash-meta: set `CGO_ENABLED=1` to avoid build failure

### DIFF
--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=clash-meta
 pkgver=1.18.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Another Clash Kernel by MetaCubeX"
 arch=('x86_64' 'aarch64' 'riscv64' 'loong64')
 url="https://github.com/MetaCubeX/Clash.Meta"
@@ -33,7 +33,7 @@ build(){
     cd "${srcdir}"/Clash.Meta-${pkgver}
     BUILDTIME=$(date -u)
     NAME=clash-meta
-    GOOS=linux CGO_ENABLED=0 go build \
+    GOOS=linux CGO_ENABLED=1 go build \
     -trimpath \
     -buildmode=pie \
     -mod=readonly \


### PR DESCRIPTION
现在沿用上游的设置`CGO_ENABLED=0`会构建出错, 调整为 `CGO_ENABLED=1` 可以构建成功。构建命令： `archlinuxcn-x86_64-build`
```
==> Starting build()...
go: downloading go.uber.org/automaxprocs v1.5.3
...
...
go: downloading github.com/pierrec/lz4/v4 v4.1.14
-linkmode requires external (cgo) linking, but cgo is not enabled
==> ERROR: A failure occurred in build().
```