### PR TITLE
fvm:  Add package

### DIFF
--- a/archlinuxcn/fvm/PKGBUILD
+++ b/archlinuxcn/fvm/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: João Victor Soares <joao.victor.ssv@outlook.com>
+
+pkgname=fvm
+pkgver=3.0.13
+pkgrel=2
+pkgdesc="Flutter Version Management: A simple cli to manage Flutter SDK versions."
+arch=('x86_64')
+url="https://github.com/leoafarias/fvm"
+license=('MIT')
+depends=('glibc'
+         'sh'
+         'git'
+         'zip' 
+         'unzip' 
+         'xz' 
+         'curl' 
+         'file' 
+         'mesa')
+optdepends=()
+source=(
+  "$url/releases/download/$pkgver/fvm-$pkgver-linux-x64.tar.gz"
+)
+conflicts=()
+OPTIONS=()
+sha256sums=(
+  '90057a5660f673441437e177671356f98f88bfffa38899a2387af40b430cc57b'
+)
+
+package() {
+  cd $srcdir
+
+  tar -xf "fvm-${pkgver}-linux-x64.tar.gz"
+  install -Dm755 "${srcdir}/fvm/fvm" "${pkgdir}/usr/share/${pkgname}/${pkgname}"
+  install -Dm664 "${srcdir}/fvm/src/dart" "${pkgdir}/usr/share/${pkgname}/src/dart"
+  install -Dm664 "${srcdir}/fvm/src/fvm.snapshot" "${pkgdir}/usr/share/${pkgname}/src/fvm.snapshot"
+  install -Dm644 "${srcdir}/fvm/src/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+  mkdir -p "${pkgdir}/usr/bin"
+  
+  chmod +x "${pkgdir}/usr/share/${pkgname}/${pkgname}"
+  chmod +x "${pkgdir}/usr/share/${pkgname}/src/dart"
+
+  ln -s "/usr/share/${pkgname}/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+}

--- a/archlinuxcn/fvm/lilac.yaml
+++ b/archlinuxcn/fvm/lilac.yaml
@@ -1,5 +1,6 @@
 maintainers:
   - github: kiri2002
+    email: kiri@vern.cc
 
 build_prefix: extra-x86_64
 

--- a/archlinuxcn/fvm/lilac.yaml
+++ b/archlinuxcn/fvm/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: kiri2002
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: leoafarias/fvm
+    use_max_tag: true


### PR DESCRIPTION
tested in extra-x86_64-build, this is namcap log:
```
cat fvm-3.0.13-2-x86_64.pkg.tar.zst-namcap.log                                                                                                        03/27/2024 09:51:49 PM PM
fvm E: ELF file ('usr/share/fvm/src/dart') outside of a valid path.
fvm E: ELF file ('usr/share/fvm/src/fvm.snapshot') outside of a valid path.
fvm W: ELF file ('usr/share/fvm/src/fvm.snapshot') lacks FULL RELRO, check LDFLAGS.
fvm W: ELF file ('usr/share/fvm/src/fvm.snapshot') is unstripped.
fvm W: ELF file ('usr/share/fvm/src/fvm.snapshot') lacks PIE.
fvm W: ELF file ('usr/share/fvm/src/dart') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
fvm W: ELF file ('usr/share/fvm/src/fvm.snapshot') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
fvm W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/share/fvm/src/dart')
fvm W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/share/fvm/src/dart')
fvm W: Dependency included, but may not be needed ('git')
fvm W: Dependency included, but may not be needed ('zip')
fvm W: Dependency included, but may not be needed ('unzip')
fvm W: Dependency included, but may not be needed ('xz')
fvm W: Dependency included, but may not be needed ('curl')
fvm W: Dependency included, but may not be needed ('file')
fvm W: Dependency included, but may not be needed ('mesa')
```

The "may not be needed" packages is same as aur and I think may should be included, since this package using various way to get and build flutter.