### PR TITLE
butterfly: Add package

### DIFF
--- a/archlinuxcn/butterfly/PKGBUILD
+++ b/archlinuxcn/butterfly/PKGBUILD
@@ -33,10 +33,11 @@ sha512sums=('0c902f6781361822e9c0e5bb4b074f6146ae50490f349b84e6157b4d6d375b4d2e6
             '5168949aae29562326da8edb738b0568bc79a5b47a70d13373065100e6cb359e0243215245d569d636a2f5b1db2081b7679ac98db1a898064559baa0f941f54c')
 
 prepare() {
+    FLUTTER_VERSION=$(cat "${_pkgname}-${pkgver}/FLUTTER_VERSION")
     cd "${_pkgname}-${pkgver}/app"
     echo ".fvm/" >> .gitignore
-    fvm install stable
-    fvm use stable
+    fvm install ${FLUTTER_VERSION}
+    fvm use ${FLUTTER_VERSION}
 
     # Disable analytics and enable linux desktop
     fvm flutter --no-version-check config --no-analytics

--- a/archlinuxcn/butterfly/PKGBUILD
+++ b/archlinuxcn/butterfly/PKGBUILD
@@ -1,0 +1,79 @@
+# Maintainer: Kiri <kiri@vern.cc>
+# Contributer: zxp19821005 <zxp19821005 at 163 dot com>
+pkgname=butterfly
+_pkgname=Butterfly
+pkgver=2.0.3
+pkgrel=1
+pkgdesc="Powerful, minimalistic, cross-platform, opensource note-taking app"
+arch=("x86_64")
+url="https://github.com/LinwoodDev/Butterfly"
+license=('AGPL-3.0-only')
+conflicts=("${pkgname%-bin}"
+           "linwood-butterfly-bin")
+depends=('gtk3'
+         'at-spi2-core'
+         'libsecret'
+         'jsoncpp'
+         'hicolor-icon-theme'
+         'libepoxy'
+         'gcc-libs'
+         'glib2'
+         'fontconfig'
+         'glibc'
+         'pango'
+         'sh')
+makedepends=('clang'
+             'fvm'
+             'cmake'
+             'ninja'
+             'patchelf')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        "${pkgname}.sh")
+sha512sums=('0c902f6781361822e9c0e5bb4b074f6146ae50490f349b84e6157b4d6d375b4d2e6922eeb7e8f0adb30423f13d39524f5f443c7ec72cc91123aa030afc821048'
+            '5168949aae29562326da8edb738b0568bc79a5b47a70d13373065100e6cb359e0243215245d569d636a2f5b1db2081b7679ac98db1a898064559baa0f941f54c')
+
+prepare() {
+    cd "${_pkgname}-${pkgver}/app"
+    fvm global stable
+
+    # Disable analytics and enable linux desktop
+    fvm flutter --no-version-check config --no-analytics
+    fvm flutter --no-version-check config --enable-linux-desktop
+
+    # Pull dependencies within prepare, allowing for offline builds later on
+    fvm flutter --no-version-check pub get
+}
+
+build() {
+    cd "${_pkgname}-${pkgver}/app"
+    fvm flutter --no-version-check build linux --release --prefixed-errors
+}
+package() {
+
+    install -Dm 755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
+
+    cd "${srcdir}/${_pkgname}-${pkgver}/app/build/linux/x64/release/bundle"
+    install -Dm 755 butterfly "${pkgdir}/usr/share/${pkgname}/butterfly"
+    install -Dm 644 lib/* -t "${pkgdir}/usr/lib/${pkgname}"
+    cp -r data "${pkgdir}/usr/share/${pkgname}/data"
+    ln -sr "${pkgdir}/usr/lib/${pkgname}" "${pkgdir}/usr/share/${pkgname}/lib"
+
+    cd "${srcdir}/${_pkgname}-${pkgver}/app/linux/debian/usr/share"
+    install -Dm 664  "applications/dev.linwood.butterfly.desktop" "${pkgdir}/usr/share/applications/dev.linwood.butterfly.desktop"
+    install -Dm 664  "icons/hicolor/128x128/apps/dev.linwood.butterfly.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/dev.linwood.butterfly.png"
+    install -Dm 664  "icons/hicolor/256x256/apps/dev.linwood.butterfly.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/dev.linwood.butterfly.png"
+    install -Dm 664  "metainfo/dev.linwood.butterfly.appdata.xml" "${pkgdir}/usr/share/metainfo/dev.linwood.butterfly.appdata.xml"
+    install -Dm 664  "mime/packages/dev.linwood.butterfly.xml" "${pkgdir}/usr/share/mime/packages/dev.linwood.butterfly.xml"
+
+
+    #fix rpath which cause "Insecure RUNPATH" or "outside of a valid path"
+    #"Insecure RUNPATH"
+    cd "${pkgdir}/usr/lib/${pkgname}"
+    patchelf --remove-rpath "libdynamic_color_plugin.so"
+    patchelf --remove-rpath "libfile_selector_linux_plugin.so"
+    patchelf --remove-rpath "libflutter_secure_storage_linux_plugin.so"
+    patchelf --set-rpath '$ORIGIN' "libprinting_plugin.so"
+    patchelf --remove-rpath "libscreen_retriever_plugin.so"
+    patchelf --remove-rpath "liburl_launcher_linux_plugin.so"
+    patchelf --remove-rpath "libwindow_manager_plugin.so"
+}

--- a/archlinuxcn/butterfly/PKGBUILD
+++ b/archlinuxcn/butterfly/PKGBUILD
@@ -66,14 +66,25 @@ package() {
     install -Dm 664  "mime/packages/dev.linwood.butterfly.xml" "${pkgdir}/usr/share/mime/packages/dev.linwood.butterfly.xml"
 
 
-    #fix rpath which cause "Insecure RUNPATH" or "outside of a valid path"
-    #"Insecure RUNPATH"
+    # Fix rpath which cause "Insecure RUNPATH" or "outside of a valid path"
+    # Fix .so files using patchelf
     cd "${pkgdir}/usr/lib/${pkgname}"
-    patchelf --remove-rpath "libdynamic_color_plugin.so"
-    patchelf --remove-rpath "libfile_selector_linux_plugin.so"
-    patchelf --remove-rpath "libflutter_secure_storage_linux_plugin.so"
-    patchelf --set-rpath '$ORIGIN' "libprinting_plugin.so"
-    patchelf --remove-rpath "libscreen_retriever_plugin.so"
-    patchelf --remove-rpath "liburl_launcher_linux_plugin.so"
-    patchelf --remove-rpath "libwindow_manager_plugin.so"
+    for file in *.so; do
+        PATCHELF_OUTPUT=$(patchelf --print-rpath $file)
+        echo "Checking $file: $PATCHELF_OUTPUT"
+    # Skip file if PATCHELF_OUTPUT does not contain CURRENT_DIR
+        if [[ ! $PATCHELF_OUTPUT =~ $CURRENT_DIR ]]; then
+            echo "Skipping $file"
+            continue
+        fi
+    # Remove rpath if it not contain ORIGIN before
+        if [[ ! $PATCHELF_OUTPUT =~ 'ORIGIN' ]]; then
+            echo "Removing rpath for $file"
+            patchelf --remove-rpath $file
+            continue
+        fi
+    # Set rpath to ORIGIN if it contain ORIGIN before
+        echo "Setting ORIGIN rpath for $file"
+        patchelf --set-rpath '$ORIGIN' $file
+    done
 }

--- a/archlinuxcn/butterfly/PKGBUILD
+++ b/archlinuxcn/butterfly/PKGBUILD
@@ -34,7 +34,9 @@ sha512sums=('0c902f6781361822e9c0e5bb4b074f6146ae50490f349b84e6157b4d6d375b4d2e6
 
 prepare() {
     cd "${_pkgname}-${pkgver}/app"
-    fvm global stable
+    echo ".fvm/" >> .gitignore
+    fvm install stable
+    fvm use stable
 
     # Disable analytics and enable linux desktop
     fvm flutter --no-version-check config --no-analytics

--- a/archlinuxcn/butterfly/butterfly.sh
+++ b/archlinuxcn/butterfly/butterfly.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec  /usr/share/butterfly/butterfly "$@"

--- a/archlinuxcn/butterfly/lilac.yaml
+++ b/archlinuxcn/butterfly/lilac.yaml
@@ -17,3 +17,4 @@ update_on:
   - source: github
     github: LinwoodDev/Butterfly
     use_max_tag: true
+    prefix: v

--- a/archlinuxcn/butterfly/lilac.yaml
+++ b/archlinuxcn/butterfly/lilac.yaml
@@ -1,5 +1,6 @@
 maintainers:
   - github: kiri2002
+    email: kiri@vern.cc
 
 build_prefix: extra-x86_64
 

--- a/archlinuxcn/butterfly/lilac.yaml
+++ b/archlinuxcn/butterfly/lilac.yaml
@@ -1,0 +1,18 @@
+maintainers:
+  - github: kiri2002
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+repo_depends:
+  - fvm
+
+update_on:
+  - source: github
+    github: LinwoodDev/Butterfly
+    use_max_tag: true


### PR DESCRIPTION
test in extra-x86_64-build with dependence "fvm"(in #3727). namcap:
```
butterfly E: ELF file ('usr/share/butterfly/butterfly') outside of a valid path.
butterfly W: ELF file ('usr/lib/butterfly/libapp.so') lacks FULL RELRO, check LDFLAGS.
butterfly W: ELF file ('usr/lib/butterfly/libapp.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
butterfly W: ELF file ('usr/lib/butterfly/libflutter_linux_gtk.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
butterfly W: ELF file ('usr/lib/butterfly/libpdfium.so') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
butterfly W: Referenced library 'libdynamic_color_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'liburl_launcher_linux_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'libfile_selector_linux_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'libprinting_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'libflutter_linux_gtk.so' is an uninstalled dependency (needed in files ['usr/lib/butterfly/libscreen_retriever_plugin.so', 'usr/share/butterfly/butterfly', 'usr/lib/butterfly/libflutter_secure_storage_linux_plugin.so', 'usr/lib/butterfly/libfile_selector_linux_plugin.so', 'usr/lib/butterfly/libdynamic_color_plugin.so', 'usr/lib/butterfly/liburl_launcher_linux_plugin.so', 'usr/lib/butterfly/libwindow_manager_plugin.so'])
butterfly W: Referenced library 'libflutter_secure_storage_linux_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'libscreen_retriever_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Referenced library 'libwindow_manager_plugin.so' is an uninstalled dependency (needed in files ['usr/share/butterfly/butterfly'])
butterfly W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/butterfly/libflutter_linux_gtk.so')
butterfly W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/butterfly/libflutter_linux_gtk.so')
butterfly W: Unused shared library '/usr/lib/libpthread.so.0' by file ('usr/lib/butterfly/libpdfium.so')
butterfly W: Dependency included, but may not be needed ('jsoncpp')
```
for the first"outside of a valid path", I checked:
```
~> readelf -d /usr/share/butterfly/butterfly |grep run                                                                                                             03/27/2024 10:17:24 PM PM
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/lib]
```
and [$ORIGIN/lib] is the link of /usr/lib/butterfly, it just fine.

I also tried not link lib to share/pkg, and set the bin's runpath to /usr/lib/xxx, but failed. 