### PR TITLE
Fix package cgproxy-git

### DIFF
--- a/archlinuxcn/cgproxy-git/PKGBUILD
+++ b/archlinuxcn/cgproxy-git/PKGBUILD
@@ -6,7 +6,6 @@ pkgdesc="A transparent proxy program powered by cgroup2 and tproxy"
 arch=('x86_64')
 url="https://github.com/springzfx/cgproxy"
 license=('GPL')
-groups=('')
 makedepends=('git' 'cmake' 'nlohmann-json' 'clang' 'bpf' 'libbpf')
 depends=('libbpf' 'iproute2' 'which')
 provides=('cgproxy')


### PR DESCRIPTION
```
groups=('')
```

is causing build failure `==> ERROR: groups does not allow empty values.`, therefore this Pr removes it.