### PR TITLE
komikku: Add package and dependence

### DIFF
--- a/archlinuxcn/komikku/PKGBUILD
+++ b/archlinuxcn/komikku/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Kiri <kiri@vern.cc>
+# Contributor: Peter Nokes <peter@peternokes.co.uk>
+
+pkgname=komikku
+_author=valos
+_gitname=Komikku
+pkgver=1.40.1
+pkgrel=1
+pkgdesc='Online/Offline Manga reader based on GNOME | PinePhone/Librem 5 Support'
+arch=(any)
+url=https://codeberg.org/valos/Komikku
+license=(GPL-3.0-only)
+depends=(libadwaita
+         python-beautifulsoup4
+         python-brotli
+         python-cairo
+         python-cffi
+         python-curl-cffi
+         python-cloudscraper
+         python-dateparser
+         python-emoji
+         python-gobject
+         python-keyring
+         python-lxml
+         python-magic
+         python-natsort
+         python-pillow
+         python-piexif
+         python-pure-protobuf
+         python-unidecode
+         python-wheel
+         python-rarfile
+         webkit2gtk
+         webkitgtk-6.0
+         python-colorthief
+         python-cryptography
+         libnotify
+         python-rarfile
+         webkitgtk-6.0
+         python-colorthief
+         gtk4
+         hicolor-icon-theme
+         dconf
+         python-pytz
+         pango
+         graphene
+         python-regex
+         python-requests
+         glib2
+         python-urllib3
+         libsoup3
+         python-tzlocal)
+makedepends=(gobject-introspection
+             meson
+             blueprint-compiler)
+optdepends=('org.freedesktop.secrets: store passwords safely')
+source=(${pkgname}-${pkgver}::"https://codeberg.org/$_author/$_gitname/archive/v$pkgver.tar.gz")
+sha256sums=('8df5c718a26615646831db6450faeb685388a4bf874bb2695de5982138269ac0')
+
+build() {
+  arch-meson $pkgname build
+  ninja -C build
+}
+
+package() {
+  DESTDIR="${pkgdir}" ninja -C build install
+}

--- a/archlinuxcn/komikku/lilac.yaml
+++ b/archlinuxcn/komikku/lilac.yaml
@@ -1,0 +1,25 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.strip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+repo_depends:
+ - python-cloudscraper
+ - python-colorthief
+ - python-curl-cffi
+ - python-dateparser
+ - python-pure-protobuf
+ - python-rarfile
+
+
+update_on:
+  - source: git
+    git: https://codeberg.org/valos/Komikku
+    use_max_tag: true

--- a/archlinuxcn/python-cloudscraper/PKGBUILD
+++ b/archlinuxcn/python-cloudscraper/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Carl Smedstad <carl.smedstad at protonmail dot com>
+# Maintainer: Carlos Aznarán <caznaranl@uni.pe>
+# Contributor: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Eli Schwartz <eschwartz@archlinux.org>
+# Contributor: Mufeed Ali <fushinari@protonmail.com>
+# Contributor: lastweakness <lastweakness@tuta.io>
+
+pkgname=python-cloudscraper
+_name=${pkgname#python-}
+pkgver=1.2.69
+pkgrel=1
+pkgdesc="Python module to bypass Cloudflare's anti-bot page"
+arch=(any)
+url="https://github.com/VeNoMouS/cloudscraper"
+license=(MIT)
+depends=("python-pyparsing"
+         "python-requests"
+         "python-requests-toolbelt"
+         "python-urllib3")
+optdepends=('nodejs: alternative interpreter/solver'
+            'python-js2py: alternative interpreter/solver')
+makedepends=("python-build"
+             "python-installer"
+             "python-wheel"
+             "python-setuptools")
+checkdepends=("nodejs"
+              "python-js2py"
+              "python-pytest"
+              "python-responses")
+
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('ee1df7b0c22529a190d12d34f2437997e6f4b68192ff965476d54cc8eb12fefa')
+
+build() {
+  cd "${_name}-${pkgver}"
+
+  python -m build --wheel --no-isolation
+}
+
+check() {
+  cd "${_name}-${pkgver}"
+
+  pytest \
+    --deselect tests/test_cloudscraper.py::TestCloudScraper::test_bad_interpreter_js_challenge1_16_05_2020 \
+    --deselect tests/test_cloudscraper.py::TestCloudScraper::test_bad_solve_js_challenge1_16_05_2020 \
+    --deselect tests/test_cloudscraper.py::TestCloudScraper::test_Captcha_challenge_12_12_2019 \
+    --deselect tests/test_cloudscraper.py::TestCloudScraper::test_reCaptcha_providers
+}
+
+package() {
+  cd "${_name}-${pkgver}"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+}

--- a/archlinuxcn/python-cloudscraper/lilac.yaml
+++ b/archlinuxcn/python-cloudscraper/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: VeNoMouS/cloudscraper
+    use_max_tag: true

--- a/archlinuxcn/python-colorthief/PKGBUILD
+++ b/archlinuxcn/python-colorthief/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Shane "SajeOne" Brown <contact@shane-brown.ca>
+pkgname=python-colorthief
+_name=color-thief-py
+pkgver=0.2.1
+pkgrel=1
+pkgdesc="A Python module for grabbing the color palette from an image."
+arch=('any')
+url="https://github.com/fengsp/color-thief-py"
+license=('BSD-3-Clause')
+depends=('python-pillow')
+makedepends=('python-setuptools')
+provides=('python-colorthief')
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('f2c47cad43809048adb9be1e4e63519d32e3b68532e8f0ab7bf46a58ddf7d099')
+
+package() {
+  cd "${srcdir}/${_name}-${pkgver}"
+  python setup.py install --root="$pkgdir/" --optimize=1
+
+  #LICENSE
+  install -D -m644 "$srcdir/${_name}-$pkgver/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/archlinuxcn/python-colorthief/lilac.yaml
+++ b/archlinuxcn/python-colorthief/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: fengsp/color-thief-py 
+    use_max_tag: true

--- a/archlinuxcn/python-curl-cffi/PKGBUILD
+++ b/archlinuxcn/python-curl-cffi/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Matthew Sexton <mssxtn@gmail.com>
+
+pkgname=python-curl-cffi
+_name=curl_cffi
+pkgver=0.6.3b1
+pkgrel=1
+pkgdesc="Python binding for curl-impersonate via CFFI"
+arch=('any')
+url="https://github.com/yifeikong/curl_cffi"
+license=('MIT')
+depends=('python-cffi'
+         'python-certifi'
+         'glibc')
+makedepends=('python-build'
+             'python-installer'
+             'python-setuptools'
+             'python-wheel' )
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('818539b13f3af3967933b26cefbe2d32a771f3ecbf8de06741e64abbf8b00dfb')
+
+build() {
+  cd "${_name}-$pkgver"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "${_name}-$pkgver"
+  python -m installer --destdir="$pkgdir" dist/*.whl
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+}

--- a/archlinuxcn/python-curl-cffi/lilac.yaml
+++ b/archlinuxcn/python-curl-cffi/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: yifeikong/curl_cffi 
+    use_latest_tag: true

--- a/archlinuxcn/python-dateparser/PKGBUILD
+++ b/archlinuxcn/python-dateparser/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Justin Kromlinger <hashworks@archlinux.org>
+# Contributor: Stefan Husmann <stefan-husmann@t-online.de>
+
+pkgname=python-dateparser
+_name=${pkgname#python-}
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="python parser for human readable dates"
+url="https://github.com/scrapinghub/dateparser"
+arch=('any')
+license=('BSD-3-Clause')
+depends=(
+  'python-dateutil'
+  'python-regex'
+  'python-tzlocal'
+  'python-pytz'
+  'python-requests'
+)
+optdepends=(
+  'python-langdetect'
+  'python-ruamel-yaml: for operations on language files'
+  'python-fasttext' # AUR
+  'python-convertdate: to convert Jalali dates to Gregorian' # AUR
+  'python-hijri-converter: to convert Hijri dates to Gregorian' # AUR
+
+)
+makedepends=("python-build"
+             "python-installer"
+             "python-wheel"
+             "python-setuptools")
+
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('13f5b024978a2251043c9d5fa937fcf2120864b36765ab8825eab79f6313fe8c')
+
+build() {
+  cd "${_name}-${pkgver}"
+
+  python -m build --wheel --no-isolation
+}
+
+# Currently: 2260 failed, 21272 passed, 14 skipped, 15 warnings in 253.79s (0:04:13)
+#check() {
+#  cd "${pkgname#python-}-${pkgver}"
+
+#  python -m pytest
+#}
+
+package() {
+  cd "${_name}-${pkgver}"
+
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.rst "${pkgdir}/usr/share/doc/${pkgname}/README.rst"
+}

--- a/archlinuxcn/python-dateparser/lilac.yaml
+++ b/archlinuxcn/python-dateparser/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: scrapinghub/dateparser 
+    use_max_tag: true

--- a/archlinuxcn/python-pure-protobuf/PKGBUILD
+++ b/archlinuxcn/python-pure-protobuf/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: <hidden>
+# Contributor: mufeed <mufeed@kumo.foo>
+pkgname=python-pure-protobuf
+_name=protobuf
+pkgver=3.0.1
+pkgrel=1
+pkgdesc='Python implementation of Protocol Buffers data types with dataclasses support.'
+arch=('any')
+url="https://github.com/eigenein/protobuf"
+license=('MIT')
+depends=("python-typing_extensions")
+makedepends=("python-poetry-dynamic-versioning")
+
+
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/${pkgver}.tar.gz")
+sha512sums=('d710a242e6e9cadc86dcaae2f28174477f76053bda501c077868fdd09597568eb52dbce02e4b463ef8cb3c9e2401d6754e333bec55614cfca1c7dc1cd7c211dd')
+
+build() {
+  cd "${srcdir}/${_name}-${pkgver}"
+  POETRY_CACHE_DIR="${srcdir}/poetry-cache" POETRY_DYNAMIC_VERSIONING_BYPASS="${pkgver}" poetry build
+}
+
+package() {
+  cd "${srcdir}/${_name}-${pkgver}"
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+}

--- a/archlinuxcn/python-pure-protobuf/lilac.yaml
+++ b/archlinuxcn/python-pure-protobuf/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: eigenein/protobuf
+    use_max_tag: true

--- a/archlinuxcn/python-rarfile/PKGBUILD
+++ b/archlinuxcn/python-rarfile/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Kiri <kiri@vern.cc>
+# Contributor: Mark Wagie <mark dot wagie at proton dot me>
+# Contributor: Sebastien Leduc <sebastien@sleduc.fr>
+# Contributor: Cedric Girard <girard.cedric@gmail.com>
+pkgname=python-rarfile
+_name=${pkgname#python-}
+pkgver=4.1
+pkgrel=2
+pkgdesc="Python module for RAR archive reading"
+arch=('any')
+url="https://github.com/markokr/rarfile"
+license=('ISC')
+depends=()
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+optdepends=('unrar: decompression backend'
+            'unarchiver: alternative decompression backend (unar)'
+            'libarchive: alternative decompression backend (bsdtar)'
+            'p7zip: alternative decompression backend (7z)'
+            '7-zip: alternative decompression backend (7zz)'
+            'python-cryptography: process archives with password-protected headers'
+            'python-pycryptodome: alternative crypto backend')
+checkdepends=('python-pytest'
+              'unarchiver'
+              'libarchive'
+              'unrar'
+              'p7zip'
+              'python-cryptography'
+              'python-pycryptodome')
+source=("${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('50cd9e283263e2b3b2762e3027f29989e0f641e8df7eb74bcba974df2f805860')
+
+build() {
+  cd "$_name-$pkgver"
+  python -m build --wheel --no-isolation
+}
+
+check() {
+  cd "$_name-$pkgver"
+  pytest -v
+}
+
+package() {
+  cd "$_name-$pkgver"
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+}

--- a/archlinuxcn/python-rarfile/lilac.yaml
+++ b/archlinuxcn/python-rarfile/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: kiri2002
+    email: kiri@vern.cc
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+
+post_build_script: |
+  git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: markokr/rarfile
+    use_max_tag: true


### PR DESCRIPTION
packages:
- komikku
dependence:
 - python-cloudscraper
 - python-colorthief
 - python-curl-cffi
 - python-dateparser
 - python-pure-protobuf
 - python-rarfile

![picture](https://apps.gnome.org/assets/screenshots/info.febvre.Komikku/image-2_orig.png)

tested in extra-x86_64:

namcap log:
- komikku:
[komikku-namcap.log](https://github.com/archlinuxcn/repo/files/14812442/komikku-namcap.log)

note:
```
komikku W: Dependency included, but may not be needed ('python-brotli')
komikku W: Dependency included, but may not be needed ('python-cairo')
komikku W: Dependency included, but may not be needed ('python-cffi')
komikku W: Dependency included, but may not be needed ('python-cloudscraper')
komikku W: Dependency included, but may not be needed ('python-lxml')
komikku W: Dependency included, but may not be needed ('python-pure-protobuf')
komikku W: Dependency included, but may not be needed ('python-wheel')
komikku W: Dependency included, but may not be needed ('webkit2gtk')
```
I try to test some of above(not tested all of them), but will not run. So I totally agree with the AUR maintainer to add them all.

- dependence:
[python-cloudscraper-1.2.69-1-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812396/python-cloudscraper-1.2.69-1-any.pkg.tar.zst-namcap.log)
[python-colorthief-0.2.1-1-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812421/python-colorthief-0.2.1-1-any.pkg.tar.zst-namcap.log)
[python-curl-cffi-0.6.3b1-1-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812435/python-curl-cffi-0.6.3b1-1-any.pkg.
[python-dateparser-1.2.0-1-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812436/python-dateparser-1.2.0-1-any.pkg.tar.zst-namcap.log)
tar.zst-namcap.log)
[python-pure-protobuf-3.0.1-1-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812438/python-pure-protobuf-3.0.1-1-any.pkg.tar.zst-namcap.log)
[python-rarfile-4.1-2-any.pkg.tar.zst-namcap.log](https://github.com/archlinuxcn/repo/files/14812439/python-rarfile-4.1-2-any.pkg.tar.zst-namcap.log)


