### PR TITLE
telegram-desktop-lily: fix build

### DIFF
--- a/archlinuxcn/telegram-desktop-lily/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-lily/PKGBUILD
@@ -20,7 +20,7 @@ depends=('hunspell'
          'libvpx' 'libvpx.so')
 makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'microsoft-gsl' 'meson'
              'extra-cmake-modules' 'wayland-protocols' 'plasma-wayland-protocols' 'libtg_owt'
-             'gobject-introspection' 'glib2' 'boost' 'fmt')
+             'gobject-introspection' 'glib2' 'boost' 'fmt' 'python-packaging')
 optdepends=('webkit2gtk: embedded browser features'
             'xdg-desktop-portal: desktop integration')
 provides=('telegram-desktop')


### PR DESCRIPTION
https://gitlab.archlinux.org/archlinux/packaging/packages/glib2/-/commit/faec2cd2cd553d1fda9446aaeade85fc0f3722ec Degraded python-packaging to an optdep of glib2.