### PR TITLE
Update PKGBUILD

### DIFF
--- a/archlinuxcn/64gram-desktop/PKGBUILD
+++ b/archlinuxcn/64gram-desktop/PKGBUILD
@@ -17,7 +17,7 @@ depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal' 'ttf-
          'openssl' 'protobuf' 'glib2' 'boost-libs' 'libsigc++-3.0' 'cppgir' 'glibmm-2.68' 'libxcomposite' 'libvpx')
 makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'microsoft-gsl' 'meson'
              'extra-cmake-modules' 'wayland-protocols' 'plasma-wayland-protocols' 'libtg_owt'
-             'gobject-introspection' 'boost' 'fmt' 'mm-common' 'perl-xml-parser' 'python-packaging')
+             'gobject-introspection' 'boost' 'fmt' 'mm-common' 'perl-xml-parser' 'python-packaging' 'libxdamage')
 optdepends=('webkit2gtk: embedded browser features'
             'xdg-desktop-portal: desktop integration')
 


### PR DESCRIPTION
https://build.archlinuxcn.org/imlonghao-api/pkg/64gram-desktop/log/1711956477

Run Build Command(s): /usr/bin/ninja -v
ninja: error: '/usr/lib/libXdamage.so', needed by 'telegram-desktop', missing and no known rule to make it

https://github.com/archlinuxcn/repo/pull/3749#issuecomment-2029331460