### PR TITLE
telegram-desktop-megumifox: add missing libxdamage dependency

### DIFF
--- a/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-megumifox/PKGBUILD
@@ -11,7 +11,7 @@ url="https://desktop.telegram.org/"
 license=('GPL3')
 depends=('hunspell' 'ffmpeg' 'hicolor-icon-theme' 'lz4' 'minizip' 'openal'
          'qt6-imageformats' 'qt6-svg' 'qt6-wayland' 'xxhash' 'glibmm-2.68'
-         'rnnoise' 'pipewire' 'libxcomposite' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
+         'rnnoise' 'pipewire' 'libxcomposite' 'libxdamage' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
          'openssl' 'protobuf')
 makedepends=('cmake' 'git' 'ninja' 'python' 'range-v3' 'tl-expected' 'microsoft-gsl' 'meson'
              'extra-cmake-modules' 'wayland-protocols' 'plasma-wayland-protocols' 'libtg_owt'


### PR DESCRIPTION
Arch did the same in https://gitlab.archlinux.org/archlinux/packaging/packages/telegram-desktop/-/commit/ce14d32d889285a4194fc9ec29c6308e08331c9c, not sure why did it build before...