### PR TITLE
telegram-desktop-lily: add missing libxdamage dependency

### DIFF
--- a/archlinuxcn/telegram-desktop-lily/PKGBUILD
+++ b/archlinuxcn/telegram-desktop-lily/PKGBUILD
@@ -14,7 +14,7 @@ depends=('hunspell'
          'ffmpeg' 'libavfilter.so' 'libavformat.so' 'libavcodec.so' 'libavutil.so'
          'hicolor-icon-theme' 'lz4' 'minizip' 'openal'
          'qt6-imageformats' 'qt6-svg' 'qt6-wayland' 'xxhash' 'glibmm-2.68'
-         'rnnoise' 'pipewire' 'libxcomposite' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
+         'rnnoise' 'pipewire' 'libxcomposite' 'libxdamage' 'libxtst' 'libxrandr' 'jemalloc' 'abseil-cpp' 'libdispatch'
          'openssl' 'libcrypto.so' 'libssl.so'
          'protobuf' 'libprotobuf-lite.so'
          'libvpx' 'libvpx.so')


### PR DESCRIPTION
Same as #3755, but for -lily.