### PR TITLE
addpkg: clash-meta

### DIFF
--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: sukanka <su975853527 at gmail dot com>
+
+pkgname=clash-meta
+pkgver=1.18.3
+pkgrel=2
+pkgdesc="Another Clash Kernel by MetaCubeX"
+arch=('x86_64' 'aarch64' 'riscv64' 'loong64')
+url="https://github.com/MetaCubeX/Clash.Meta"
+license=("GPL3")
+depends=('glibc' 'clash-geoip')
+makedepends=('go')
+conflicts=(clash-meta)
+backup=('etc/clash-meta/config.yaml')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        "clash-meta.service"
+        "clash-meta@.service"
+        "${pkgname}.sysusers"
+        "${pkgname}.tmpfiles"
+)
+sha256sums=('d070c4b464650093c6a29ef475f1cf5beec7c4b93e7704ca01eaf01f6a56a020'
+            'b6b7ce11489a6f6322a41ce840b3f999b1ec88914f8bd6864c220269231bf759'
+            'ec4de877464e595124a5f2752c3f4be157adc85ec5f7f8392c0331cb70fc906a'
+            '655e8e2edcd82a6bdf2fd12430b7ab6f8e32db8dffce70e7342685a7cc65ebfb'
+            '50737592c7bd743fe8f543924034718337477a203fa11ef4272cae496df3769c')
+
+prepare(){
+    cd "${srcdir}"
+    mv mihomo-${pkgver} Clash.Meta-${pkgver}
+    cd Clash.Meta-${pkgver}
+    sed -i 's|^const.*|const Name = "clash"|g' constant/path.go
+}
+build(){
+    cd "${srcdir}"/Clash.Meta-${pkgver}
+    BUILDTIME=$(date -u)
+    NAME=clash-meta
+    GOOS=linux CGO_ENABLED=1 go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-linkmode external -extldflags '${LDFLAGS}' \
+    -X 'github.com/metacubex/mihomo/constant.Version=${pkgver}' \
+    -X 'github.com/metacubex/mihomo/constant.BuildTime=${BUILDTIME}' \
+    " \
+    -tags with_gvisor -o ${pkgname}-${pkgver}
+}
+package() {
+    cd "${srcdir}"/Clash.Meta-${pkgver}
+    install -Dm755 "${pkgname}-${pkgver}" "${pkgdir}/usr/bin/clash-meta"
+    install -Dm644 "docs/config.yaml" -t "${pkgdir}/etc/clash-meta"
+    cd $srcdir
+    install -Dm644 ${pkgname}.sysusers "${pkgdir}/usr/lib/sysusers.d/${pkgname}.conf"
+    install -Dm644 ${pkgname}.tmpfiles "${pkgdir}/usr/lib/tmpfiles.d/${pkgname}.conf"
+    install -Dm644 "clash-meta.service"  -t "${pkgdir}/usr/lib/systemd/system"
+    install -Dm644 "clash-meta@.service" -t "${pkgdir}/usr/lib/systemd/system"
+    ln -sf /etc/clash/Country.mmdb ${pkgdir}/etc/${pkgname}/Country.mmdb
+    #geosite.dat from community repo does not work
+    # ln -sf /usr/share/v2ray/geosite.dat ${pkgdir}/etc/${pkgname}/GeoSite.dat
+}

--- a/archlinuxcn/clash-meta/clash-meta.service
+++ b/archlinuxcn/clash-meta/clash-meta.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Clash-Meta Daemon, Another Clash Kernel.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=simple
+User=clash-meta
+Group=clash-meta
+LimitNPROC=500
+LimitNOFILE=1000000
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
+Restart=always
+RestartSec=5
+ExecStart=/usr/bin/clash-meta -d /etc/clash-meta
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinuxcn/clash-meta/clash-meta.sysusers
+++ b/archlinuxcn/clash-meta/clash-meta.sysusers
@@ -1,0 +1,1 @@
+u "clash-meta" - - - -

--- a/archlinuxcn/clash-meta/clash-meta.tmpfiles
+++ b/archlinuxcn/clash-meta/clash-meta.tmpfiles
@@ -1,0 +1,2 @@
+d /etc/clash-meta 0755 clash-meta clash-meta -
+d /var/log/clash-meta 0700 clash-meta clash-meta -

--- a/archlinuxcn/clash-meta/clash-meta@.service
+++ b/archlinuxcn/clash-meta/clash-meta@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Clash-Meta Daemon for %i.
+After=network.target NetworkManager.service systemd-networkd.service iwd.service
+
+[Service]
+Type=exec
+User=%i
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
+Restart=on-abort
+ExecStart=/usr/bin/clash-meta
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinuxcn/clash-meta/lilac.yaml
+++ b/archlinuxcn/clash-meta/lilac.yaml
@@ -4,18 +4,21 @@ maintainers:
 build_prefix: extra-x86_64
 
 pre_build_script: |
-  aur_pre_build(maintainers=['sukanka'])
+  update_pkgver_and_pkgrel(_G.newver)
 
-post_build: |
-  aur_post_build
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
 
 repo_depends:
   - clash-geoip
 
 update_on:
-  - source: aur
-    aur: clash-meta
   - source: github
-    github: MetaCubeX/mihomo
+    github: MetaCubeX/Clash.Meta
     use_latest_release: true
     prefix: v
+  - source: aur
+    aur: clash-meta
+  - source: manual
+    manual: 1


### PR DESCRIPTION
This pr just adds clash-meta back. 

Previous commits by [Zenvie](https://github.com/sukanka/repo/commits?author=Zenvie) have also been reverted, as they break user service and backward compatibility.

I decided to not adopt the upstream service file as we use the `clash-meta` user for its daemon instead of the `root` for security reasons.