### PR TITLE
supergfxctl-git: fix PKGBUILD

### DIFF
--- a/archlinuxcn/supergfxctl-git/PKGBUILD
+++ b/archlinuxcn/supergfxctl-git/PKGBUILD
@@ -9,7 +9,7 @@ url="https://gitlab.com/asus-linux/supergfxctl"
 license=('MPL2')
 depends=('systemd-libs')
 makedepends=('git' 'rust' 'systemd')
-provides=('supergfxctl')
+provides=("supergfxctl=$pkgver")
 conflicts=('supergfxctl')
 source=('git+https://gitlab.com/asus-linux/supergfxctl.git')
 md5sums=('SKIP')


### PR DESCRIPTION
archlinuxcn/supergfxctl-git lacks version information in `provides`, making it fail when installing aur/plasma6-applets-supergfxctl, which requires `supergfxctl>=5.1.0`.