### PR TITLE
[ocaml-menhir] More aggressive autobuild trigger when ocaml is updated

### DIFF
--- a/archlinuxcn/ocaml-menhir/lilac.yaml
+++ b/archlinuxcn/ocaml-menhir/lilac.yaml
@@ -4,8 +4,6 @@ update_on:
   - source: aur
     aur: ocaml-menhir
   - source: alpm
-    from_pattern: ^(\d+\.\d+)\..*
-    to_pattern: \1
     alpm: ocaml
     repo: extra
 maintainers:


### PR DESCRIPTION
The update from ocaml 5.1.0 to 5.1.1 causes the build of herdtools7-git to fail with error:

   Error: Files /usr/lib/ocaml/menhirLib/menhirLib.cmxa
   and /usr/lib/ocaml/stdlib.cmxa
   make inconsistent assumptions over implementation Stdlib__Sys

AFAICT, this is caused by changes/recompilation of the standard library and is fixed by recompiling menhir.

It seems that just triggering rebuild on minor version update is not enough. I don't know if triggering on pkgrel update is necessary but it's included here just to be safe.

This may need to be applied to other ocaml packages.