### PR TITLE
librewolf: fix missing icon when running under wayland

### DIFF
--- a/archlinuxcn/librewolf/PKGBUILD
+++ b/archlinuxcn/librewolf/PKGBUILD
@@ -111,7 +111,7 @@ ac_add_options --enable-update-channel=release
 # ac_add_options --with-app-basename=${_pkgname}
 
 # needed? yep.
-export MOZ_APP_REMOTINGNAME=${_pkgname}
+export MOZ_APP_REMOTINGNAME=${pkgname}
 
 # System libraries
 ac_add_options --with-system-nspr


### PR DESCRIPTION
Currently, when running LibreWolf under Wayland, the icon will fallback to the Wayland default one.

Setting the correct ```MOZ_APP_REMOTINGNAME``` can fix the icon.