### PR TITLE
devtools-archlinuxcn: update to 1.2.0

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -5,10 +5,10 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.1.1
-pkgrel=2
+pkgver=1.2.0
+pkgrel=1
 # curl https://api.github.com/repos/archlinuxcn/devtools/git/ref/tags/$pkgver-archlinuxcn1 | jq -r .object.sha
-_tag=1184c720ee2ed94963e9efa96d2583023e9d520b
+_tag=74fb845cf28be24f73fbb1b096fad64e4f725d2c
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
 arch=('any')
@@ -22,6 +22,7 @@ depends=(
   coreutils
   curl
   diffutils
+  expac
   fakeroot
   findutils
   grep
@@ -38,14 +39,16 @@ depends=(
   subversion
 )
 makedepends=(
-  asciidoc
+  asciidoctor
   shellcheck
+)
+checkdepends=(
+  bats
 )
 optdepends=(
   'btrfs-progs: btrfs support'
   'bat: pretty printing for pkgctl search'
   'nvchecker: pkgctl version subcommand'
-  'pacman-contrib: support for the --update-checksums option'
 )
 provides=("devtools=$pkgver-$pkgrel")
 conflicts=("devtools")
@@ -63,6 +66,11 @@ pkgver() {
 build() {
   cd ${pkgname}
   make BUILDTOOLVER="${epoch}:${pkgver}-${_upstream_pkgrel}-${arch}" PREFIX=/usr
+}
+
+check() {
+  cd ${pkgname}
+  make PREFIX=/usr test
 }
 
 package() {


### PR DESCRIPTION
PKGBUILD is synced with extra/devtools again

Rebase conflicts:
* `makechrootpkg: support bind mount tmpfs besides existing directories` conflicts with [1]
* `Handle ArchLinuxARM server URL in arch-nspawn" conflicts with` conflicts with [2]
* `Revert "makechrootpkg: when installing with -I, ensure package is installed"` not needed after [1]

[1] https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/245
[2] https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/244

---

Some other notes:
* I only test building this package. More testing is necessary.
* sudoers may need to allow a new environment variable `LOGDEST`. I got the following error with `offload-build --server build.archlinuxcn.org`:
```
sudo: sorry, you are not allowed to set the following environment variables: LOGDEST
```
The change seems related to https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/220
* For `feat(arch-nspawn): use --keep-unit when running inside a service`, [the upstream patch](https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/197) now uses an environment variable instead of checking cgroup information. Do you want to keep the current approach or switch to the one proposed there?
* There are many [upstream commits](https://github.com/archlinux/devtools/compare/v1.1.1...v1.2.0). Besides merge requests mentioned above, some may also break [archlinuxcn] packages:
    *  [feat(makepkg.conf): Increase _FORTIFY_SOURCE level to 3](https://github.com/archlinux/devtools/commit/c79a99314822fe4238b66f92c81b288208073a24): known to cause some incompatibilities, see https://archlinux.org/todo/prepare-packages-for-d_fortify_source3/