### PR TITLE
fix(llvm-git): adding spirv-tools-git

### DIFF
--- a/archlinuxcn/llvm-git/PKGBUILD
+++ b/archlinuxcn/llvm-git/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=('git' 'cmake' 'ninja' 'libffi' 'libedit' 'ncurses' 'libxml2'
              'cuda' 'ocl-icd' 'opencl-headers' 'python-yaml' 'python-myst-parser'
              'swig' 'python' 'libunwind' 'spirv-headers-git'
              'python-sphinx-furo' 'python-sphinx-automodapi' 'python-pexpect'
-             'python-psutil' 'spirv-tools' 'tensorflow')
+             'python-psutil' 'spirv-tools-git' 'tensorflow')
 
 source=("llvm-project::git+https://github.com/llvm/llvm-project.git"
         "git+https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git"

--- a/archlinuxcn/llvm-git/lilac.yaml
+++ b/archlinuxcn/llvm-git/lilac.yaml
@@ -7,6 +7,7 @@ time_limit_hours: 2
 repo_makedepends:
     - python-sphinx-automodapi
     - spirv-headers-git
+    - spirv-tools-git
 update_on:
     - source: cmd
       cmd: python -c "import time; print(int(time.time()) // (2 * 24 * 60 * 60))"


### PR DESCRIPTION
because of rational decision that i've seen, it wants the git version of spirv-tools-git