### PR TITLE
feat(lib32-spirv-tools-git): adding lib32-spirv-tools-git

### DIFF
--- a/archlinuxcn/lib32-spirv-tools-git/PKGBUILD
+++ b/archlinuxcn/lib32-spirv-tools-git/PKGBUILD
@@ -1,0 +1,81 @@
+# Maintainer: Lone_Wolf <Lone_Wolf@klaas-de-kat.nl>
+# Contributor: Eric Engestrom <aur [at] engestrom [dot] ch>
+# Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Laurent Carlier <lordheavym@gmail.com>
+
+
+pkgname=lib32-spirv-tools-git
+pkgver="2024.2".3950.199038f10
+pkgrel=1
+pkgdesc='API and commands for processing SPIR-V modules (32-bit version)'
+url='https://github.com/KhronosGroup/SPIRV-Tools'
+arch=('i686' 'x86_64')
+license=('Apache-2.0')
+source=('git+https://github.com/KhronosGroup/SPIRV-Tools'
+              'git+https://github.com/google/googletest.git'
+              'git+https://github.com/google/effcee.git'
+              'git+https://github.com/google/re2.git'
+              'git+https://github.com/abseil/abseil-cpp.git'
+)
+sha1sums=('SKIP'
+          'SKIP'
+          'SKIP'
+          'SKIP'
+          'SKIP')
+depends=(lib32-glibc lib32-gcc-libs spirv-tools-git sh)
+makedepends=(cmake python git spirv-headers-git)
+conflicts=(lib32-spirv-tools)
+provides=(lib32-spirv-tools)
+
+
+cmake_args=(
+  -G "Unix Makefiles"
+  -D CMAKE_BUILD_TYPE=Release
+  -D CMAKE_INSTALL_PREFIX=/usr
+  -D CMAKE_INSTALL_LIBDIR=lib32
+  -D SPIRV-Headers_SOURCE_DIR=/usr/
+  -D BUILD_SHARED_LIBS=ON
+  -D SPIRV_TOOLS_BUILD_STATIC=OFF
+  -D SPIRV_WERROR=OFF
+)
+
+prepare() {
+  # link external sources so cmake can find them
+  pushd SPIRV-Tools/external
+  ln -s "$srcdir"/googletest
+  ln -s  $srcdir/abseil-cpp abseil_cpp
+  ln -s "$srcdir"/effcee
+  ln -s "$srcdir"/re2
+  popd
+
+  export CC='gcc -m32'
+  export CXX='g++ -m32'
+  export PKG_CONFIG=i686-pc-linux-gnu-pkg-config
+
+  cmake   -S SPIRV-Tools -B _build "${cmake_args[@]}" -Wno-dev
+  make -C _build spirv-tools-build-version
+}
+
+pkgver() {
+  local _ver1 _ver2
+  # read fails if only 1 var is used
+  IFS="," read -r _ver1 _ver2 < _build/build-version.inc || [ -n "_ver1" ]
+
+  cd SPIRV-Tools  
+  echo ${_ver1//v/}.$(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+}
+
+
+
+build() {
+  make -C _build
+}
+
+check() {
+    make -C _build test
+}
+
+package() {
+  make -C _build DESTDIR="$pkgdir" install
+  rm -r "$pkgdir"/usr/{bin,include}
+}

--- a/archlinuxcn/lib32-spirv-tools-git/lilac.yaml
+++ b/archlinuxcn/lib32-spirv-tools-git/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+    - github: solaraquarion
+build_prefix: multilib
+
+pre_build_script: vcs_update
+post_build: git_pkgbuild_commit
+
+repo_makedepends:
+    - spirv-headers-git
+update_on:
+    - source: github
+      github: KhronosGroup/SPIRV-Tools


### PR DESCRIPTION
in my local copy lib32-llvm-git has multiple changes which enable lib32 llvm translator