### PR TITLE
fix(lib32-llvm-git): fixing lilac.yaml

### DIFF
--- a/archlinuxcn/lib32-llvm-git/lilac.yaml
+++ b/archlinuxcn/lib32-llvm-git/lilac.yaml
@@ -5,7 +5,8 @@ build_prefix: multilib
 pre_build: vcs_update
 post_build: git_pkgbuild_commit
 repo_makedepends:
-    - llvm-git
+    - llvm-git: llvm-git
+    - llvm-git: llvm-libs-git
     - spirv-headers-git
     - lib32-spirv-tools-git
 time_limit_hours: 2


### PR DESCRIPTION
adding the dependant packages of the split package so things build