### PR TITLE
fix(lib32-llvm-git): adding spirv-tools-git

### DIFF
--- a/archlinuxcn/lib32-llvm-git/lilac.yaml
+++ b/archlinuxcn/lib32-llvm-git/lilac.yaml
@@ -9,6 +9,7 @@ repo_makedepends:
     - llvm-git: llvm-libs-git
     - spirv-headers-git
     - lib32-spirv-tools-git
+    - spirv-tools-git
 time_limit_hours: 2
 
 update_on:


### PR DESCRIPTION
necessary repo_makedepends according to the logs of lilac