### PR TITLE
clash-verge: fix icon file

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -66,5 +66,7 @@ package() {
 	ln -sf /etc/clash/Country.mmdb -t ${pkgdir}/usr/lib/${pkgname}/resources
  	install -Dm755 src-tauri/target/release/resources/{clash-verge,install,uninstall}-service -t ${pkgdir}/usr/lib/${pkgname}/resources
 
+	install -Dm644  src-tauri/icons/icon.png ${pkgdir}/usr/share/icons/hicolor/512x512/apps/${pkgname}.png
+
 	install -Dm644 ${srcdir}/${pkgname}.desktop -t ${pkgdir}/usr/share/applications
 }

--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -66,7 +66,5 @@ package() {
 	ln -sf /etc/clash/Country.mmdb -t ${pkgdir}/usr/lib/${pkgname}/resources
  	install -Dm755 src-tauri/target/release/resources/{clash-verge,install,uninstall}-service -t ${pkgdir}/usr/lib/${pkgname}/resources
 
-	install -Dm644 src/assets/image/logo.bak.svg ${pkgdir}/usr/share/icons/hicolor/scalable/apps/${pkgname}.svg
-
 	install -Dm644 ${srcdir}/${pkgname}.desktop -t ${pkgdir}/usr/share/applications
 }

--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -66,7 +66,7 @@ package() {
 	ln -sf /etc/clash/Country.mmdb -t ${pkgdir}/usr/lib/${pkgname}/resources
  	install -Dm755 src-tauri/target/release/resources/{clash-verge,install,uninstall}-service -t ${pkgdir}/usr/lib/${pkgname}/resources
 
-	install -Dm644  src-tauri/icons/icon.png ${pkgdir}/usr/share/icons/hicolor/512x512/apps/${pkgname}.png
+	install -Dm644 src-tauri/icons/icon.png ${pkgdir}/usr/share/icons/hicolor/512x512/apps/${pkgname}.png
 
 	install -Dm644 ${srcdir}/${pkgname}.desktop -t ${pkgdir}/usr/share/applications
 }


### PR DESCRIPTION
Upstream has removed `logo.bak.svg`. There is no need for an explicit install now