### PR TITLE
addpkg: yass-proxy-cli, yass-proxy-gtk3, yass-proxy-qt5, yass-proxy-qt6

### DIFF
--- a/archlinuxcn/yass-proxy-cli/lilac.yaml
+++ b/archlinuxcn/yass-proxy-cli/lilac.yaml
@@ -1,0 +1,12 @@
+pre_build_script: aur_pre_build(maintainers=['hky'])
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: yass-proxy-cli
+  - source: manual
+    manual: 1.0
+
+maintainers:
+  - github: Chilledheart

--- a/archlinuxcn/yass-proxy-gtk3/lilac.yaml
+++ b/archlinuxcn/yass-proxy-gtk3/lilac.yaml
@@ -1,0 +1,12 @@
+pre_build_script: aur_pre_build(maintainers=['hky'])
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: yass-proxy-gtk3
+  - source: manual
+    manual: 1.0
+
+maintainers:
+  - github: Chilledheart

--- a/archlinuxcn/yass-proxy-qt5/lilac.yaml
+++ b/archlinuxcn/yass-proxy-qt5/lilac.yaml
@@ -1,0 +1,12 @@
+pre_build_script: aur_pre_build(maintainers=['hky'])
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: yass-proxy-qt5
+  - source: manual
+    manual: 1.0
+
+maintainers:
+  - github: Chilledheart

--- a/archlinuxcn/yass-proxy-qt6/lilac.yaml
+++ b/archlinuxcn/yass-proxy-qt6/lilac.yaml
@@ -1,0 +1,12 @@
+pre_build_script: aur_pre_build(maintainers=['hky'])
+
+post_build: aur_post_build
+
+update_on:
+  - source: aur
+    aur: yass-proxy-qt6
+  - source: manual
+    manual: 1.0
+
+maintainers:
+  - github: Chilledheart


### PR DESCRIPTION

below packages are affected:

- yass-proxy-cli: CLI variant of yass-proxy

- yass-proxy: GTK4 variant of yass-proxy
- yass-proxy-gtk3: GTK3 variant of yass-proxy
- yass-proxy-qt5: QT5 variant of yass-proxy
- yass-proxy-qt6: QT6 variant of yass-proxy
