### PR TITLE
clash-verge: fix mihomo name

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -65,6 +65,7 @@ package() {
 
 	install -d ${pkgdir}/usr/lib/${pkgname}/resources
 	ln -sf /etc/clash/Country.mmdb -t ${pkgdir}/usr/lib/${pkgname}/resources
+        ln -f /usr/bin/clash-meta -t ${pkgdir}/usr/bin/verge-mihomo
  	install -Dm755 src-tauri/target/release/resources/{clash-verge,install,uninstall}-service -t ${pkgdir}/usr/lib/${pkgname}/resources
 
 	install -Dm644 src-tauri/icons/icon.png ${pkgdir}/usr/share/icons/hicolor/512x512/apps/${pkgname}.png


### PR DESCRIPTION
The new version of clash-verge call verge-mihomo which is just clash-meta. And the process-name need to be verge-mihomo also, so here use a hard link