### PR TITLE
clash-verge: soft link clash-meta to verge-mihomo

### DIFF
--- a/archlinuxcn/clash-verge/PKGBUILD
+++ b/archlinuxcn/clash-verge/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=clash-verge
 pkgver=1.7.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A Clash Meta GUI based on Tauri, Continuation of Clash Verge"
 arch=('x86_64' 'aarch64')
 url="https://github.com/clash-verge-rev/clash-verge-rev"
@@ -65,7 +65,7 @@ package() {
 
 	install -d ${pkgdir}/usr/lib/${pkgname}/resources
 	ln -sf /etc/clash/Country.mmdb -t ${pkgdir}/usr/lib/${pkgname}/resources
-        ln -f /usr/bin/clash-meta -t ${pkgdir}/usr/bin/verge-mihomo
+        ln -sf /usr/bin/clash-meta -t ${pkgdir}/usr/bin/verge-mihomo
  	install -Dm755 src-tauri/target/release/resources/{clash-verge,install,uninstall}-service -t ${pkgdir}/usr/lib/${pkgname}/resources
 
 	install -Dm644 src-tauri/icons/icon.png ${pkgdir}/usr/share/icons/hicolor/512x512/apps/${pkgname}.png


### PR DESCRIPTION
Sorry for the mistake, the hard link will point to the compile machine's clash-meta.
And the soft link also can create a new progress name which is verge-mihomo.
So here should be soft link 