### PR TITLE
addpkg: serenity

### DIFF
--- a/archlinuxcn/serenity/PKGBUILD
+++ b/archlinuxcn/serenity/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer:  Misaka13514 <Misaka13514 at gmail dot com>
+# Contributor: Henry-ZHR <henry-zhr@qq.com>
+
+pkgname=serenity
+pkgver=1.0.0beta.17
+_tagname='1.0.0-beta.17'
+pkgrel=1
+pkgdesc='The configuration generator for sing-box'
+arch=('i686' 'x86_64' 'aarch64' 'armv7h')
+url='https://github.com/SagerNet/serenity'
+license=('custom:GPL-3.0-or-later WITH name use or association addition')
+depends=('glibc')
+makedepends=('go')
+optdepends=('sing-box')
+backup=("etc/$pkgname/config.json")
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$_tagname.tar.gz")
+sha256sums=('1278f75334cf908717a90745aa1e179227ffaaa98b5e6832df6be6d61b24b3c0')
+
+prepare() {
+  cd $pkgname-$_tagname
+  mkdir -p build/
+}
+
+build() {
+  cd $pkgname-$_tagname
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+
+  go build \
+    -ldflags "-X github.com/sagernet/serenity/constant.Version=${pkgver} -linkmode external -s -w" \
+    -o build -v ./cmd/...
+  go run ./cmd/$pkgname completion bash > build/bash-completion
+  go run ./cmd/$pkgname completion fish > build/fish-completion
+  go run ./cmd/$pkgname completion zsh > build/zsh-completion
+}
+
+check() {
+  cd $pkgname-$_tagname
+  go test ./...
+}
+
+package() {
+  cd $pkgname-$_tagname
+  install -Dm755 build/$pkgname $pkgdir/usr/bin/$pkgname
+  install -Dm644 build/bash-completion "$pkgdir/usr/share/bash-completion/completions/$pkgname"
+  install -Dm644 build/fish-completion "$pkgdir/usr/share/fish/vendor_completions.d/$pkgname.fish"
+  install -Dm644 build/zsh-completion "$pkgdir/usr/share/zsh/site-functions/_$pkgname"
+  install -Dm644 release/config/config.json "$pkgdir/etc/$pkgname/config.json"
+  install -Dm644 release/config/$pkgname.service "$pkgdir/usr/lib/systemd/system/$pkgname.service"
+  install -Dm644 release/config/$pkgname@.service "$pkgdir/usr/lib/systemd/system/$pkgname@.service"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/archlinuxcn/serenity/lilac.yaml
+++ b/archlinuxcn/serenity/lilac.yaml
@@ -1,0 +1,19 @@
+maintainers:
+  - github: Misaka13514
+
+pre_build_script: |
+  tag = _G.newver.lstrip('v')
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('_tagname='):
+      line = f"_tagname='{tag}'"
+    print(line)
+  update_pkgver_and_pkgrel(tag.replace('-', ''))
+
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+
+update_on:
+  - source: github
+    github: SagerNet/serenity
+    use_latest_release: true


### PR DESCRIPTION
[serenity](https://github.com/SagerNet/serenity): The configuration generator for sing-box

https://aur.archlinux.org/packages/serenity

## log

- [PKGBUILD-namcap.log](https://github.com/user-attachments/files/16216186/PKGBUILD-namcap.log)
- [serenity-1.0.0_beta.13-2-x86_64.pkg.tar.zst-namcap.log](https://github.com/user-attachments/files/16216187/serenity-1.0.0_beta.13-2-x86_64.pkg.tar.zst-namcap.log)
- [serenity-1.0.0_beta.13-2-x86_64-build.log](https://github.com/user-attachments/files/16216188/serenity-1.0.0_beta.13-2-x86_64-build.log)
- [serenity-1.0.0_beta.13-2-x86_64-check.log](https://github.com/user-attachments/files/16216189/serenity-1.0.0_beta.13-2-x86_64-check.log)
- [serenity-1.0.0_beta.13-2-x86_64-package.log](https://github.com/user-attachments/files/16216190/serenity-1.0.0_beta.13-2-x86_64-package.log)
- [serenity-1.0.0_beta.13-2-x86_64-prepare.log](https://github.com/user-attachments/files/16216191/serenity-1.0.0_beta.13-2-x86_64-prepare.log)
- [serenity-debug-1.0.0_beta.13-2-x86_64.pkg.tar.zst-namcap.log](https://github.com/user-attachments/files/16216192/serenity-debug-1.0.0_beta.13-2-x86_64.pkg.tar.zst-namcap.log)


## namcap

```
serenity W: ELF file ('usr/bin/serenity') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
serenity E: custom:GPL-3.0-or-later WITH name use or association addition is an invalid license string.
serenity-debug W: Directory (usr/src/debug/serenity) is empty
```
