### PR TITLE
v2raya: depends on v2raya-core

### DIFF
--- a/archlinuxcn/v2raya-core/PKGBUILD
+++ b/archlinuxcn/v2raya-core/PKGBUILD
@@ -1,0 +1,14 @@
+# Maintainer: Rocket Aaron <i at rocka dot me>
+
+pkgname='v2raya-core'
+pkgdesc='v2ray core for v2rayA'
+pkgver=1
+pkgrel=1
+url='https://github.com/v2fly/v2ray-core'
+license=('MIT')
+depends=('v2ray')
+arch=('any')
+
+package() {
+    # nothing to package
+}

--- a/archlinuxcn/v2raya-core/lilac.yaml
+++ b/archlinuxcn/v2raya-core/lilac.yaml
@@ -1,0 +1,7 @@
+update_on:
+  - source: manual
+    manual: 1
+
+maintainers:
+  - github: rocka
+  - github: zjuyk

--- a/archlinuxcn/v2raya/PKGBUILD
+++ b/archlinuxcn/v2raya/PKGBUILD
@@ -7,8 +7,8 @@ pkgrel=1
 pkgdesc="A web GUI client of Project V which supports VMess, VLESS, SS, SSR, Trojan and Pingtunnel protocols"
 arch=('x86_64')
 url="https://github.com/v2rayA/v2rayA"
-license=('AGPL3')
-depends=('glibc')
+license=('AGPL-3.0')
+depends=('glibc' 'v2raya-core')
 makedepends=('git' 'go>=2:1.17.0-1' 'nodejs<=19' 'yarn')
 backup=("etc/default/v2raya")
 install="${pkgname}.install"
@@ -39,8 +39,6 @@ build() {
 }
 
 package() {
-    depends+=('v2ray')
-
     cd "${srcdir}"/"${_pkgname}-${pkgver}"/
     install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/v2raya/
     install -Dm 755 service/v2raya -t "${pkgdir}"/usr/bin/

--- a/archlinuxcn/v2raya/lilac.yaml
+++ b/archlinuxcn/v2raya/lilac.yaml
@@ -1,3 +1,6 @@
+repo_depends:
+  - v2raya-core
+
 pre_build_script: |
     update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
 


### PR DESCRIPTION
xray provides `v2raya-core` since https://github.com/archlinuxcn/repo/commit/a45645ba7ea57e2d3b0753b5b41667f2e97df87b