### PR TITLE
xray-geodata: replaces old xray-domain-list-community

### DIFF
--- a/archlinuxcn/xray-geodata/PKGBUILD
+++ b/archlinuxcn/xray-geodata/PKGBUILD
@@ -24,7 +24,8 @@ package_xray-geosite() {
     url='https://github.com/v2fly/domain-list-community'
     license=('MIT')
     depends=('v2ray-domain-list-community')
-
+    replaces=('xray-domain-list-community')
+    
     # v2ray-domain-list-community compatibility
     install -d "${pkgdir}"/usr/share/xray/
     ln -s ../v2ray/geosite.dat "${pkgdir}"/usr/share/xray/geosite.dat


### PR DESCRIPTION
Now `xray` depends on `xray-geodata`, which depends v2ray geodata from official repo.

Existing user installation containg `xray-domian-list-community` cannot directly upgrade because of file confliction with new `xray-geosite`.

Here adds `replaces=('xray-domain-list-community')` into `xray-geosite` to hopefully archieve smooth upgration.