### PR TITLE
Revert "update README about farseerfc key"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ Import PGP Keys:
 sudo pacman -Sy && sudo pacman -S archlinuxcn-keyring
 ```
 
-Due to a developer's retirement, newly installed systems need to manually trust farseerfc's key:
-
-```bash
-sudo pacman-key --lsign-key "farseerfc@archlinux.org"
-```
-
 ### Issues
 
 * Flag package OUT-OF-DATE by submiting new issues (please follow the template).


### PR DESCRIPTION
archlinuxcn-keyring is now packaged by Felix Yan.

This reverts commit b084f50e1e76da77db11bf673af3df9d467e5f7d.