### PR TITLE
waypipe: update_on ffmpeg

### DIFF
--- a/archlinuxcn/waypipe/lilac.yaml
+++ b/archlinuxcn/waypipe/lilac.yaml
@@ -4,5 +4,9 @@ post_build: aur_post_build
 update_on:
   - source: aur
     aur: waypipe
+  - source: alpm
+    alpm: ffmpeg
+    provided: libavcodec.so
+
 maintainers:
   - github: roaldclark


### PR DESCRIPTION
waypipe: error while loading shared libraries: libavcodec.so.60: cannot open shared object file: No such file or directory