### PR TITLE
imhex: add libxrandr to makedepends

### DIFF
--- a/archlinuxcn/imhex/PKGBUILD
+++ b/archlinuxcn/imhex/PKGBUILD
@@ -23,7 +23,7 @@ depends=(
     'libarchive'
     'glibc' 'gcc-libs' 'bash'
 )
-makedepends=('git' 'cmake' 'ninja' 'llvm' 'nlohmann-json' 'librsvg' 'python' 'dotnet-runtime')
+makedepends=('git' 'cmake' 'ninja' 'llvm' 'nlohmann-json' 'librsvg' 'python' 'dotnet-runtime' 'libxrandr')
 optdepends=(
     'imhex-patterns-git: ImHex base patterns'
     'dotnet-runtime'


### PR DESCRIPTION
Ref:

-   https://aur.archlinux.org/cgit/aur.git/commit/?h=imhex&id=4c1f6fceb63df8a6142e1ec930635518a2e9b962

-   https://build.archlinuxcn.org/packages/#/imhex/logs/1726172704

    ```
    In file included from /build/imhex/src/imhex/lib/third_party/nativefiledialog/src/include/nfd_glfw3.h:15,
                    from /build/imhex/src/imhex/lib/libimhex/source/helpers/fs.cpp:44:
    /usr/include/GLFW/glfw3native.h:119:12: fatal error: X11/extensions/Xrandr.h: No such file or directory
    119 |   #include <X11/extensions/Xrandr.h>
        |            ^~~~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    ```

fix #4018