### PR TITLE
gtk3-lily: add patch to inhibit Ctrl-Shift-U unicode input

### DIFF
--- a/archlinuxcn/gtk3-lily/0001-inhibit-hex-check.patch
+++ b/archlinuxcn/gtk3-lily/0001-inhibit-hex-check.patch
@@ -1,0 +1,31 @@
+From ad1bc987cb0cb093ec81bdda1fb45af45faa2994 Mon Sep 17 00:00:00 2001
+From: Carl Lei <me@xecycle.info>
+Date: Sun, 3 Nov 2024 13:12:20 +0800
+Subject: [PATCH] inhibit hex check
+
+---
+ gtk/gtkimcontextsimple.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/gtk/gtkimcontextsimple.c b/gtk/gtkimcontextsimple.c
+index ccf9687ba6..10ada47156 100644
+--- a/gtk/gtkimcontextsimple.c
++++ b/gtk/gtkimcontextsimple.c
+@@ -766,12 +766,8 @@ gtk_im_context_simple_filter_keypress (GtkIMContext *context,
+     have_hex_mods = TRUE;
+   else
+     have_hex_mods = (event->state & (hex_mod_mask)) == hex_mod_mask;
+-  is_hex_start = event->keyval == GDK_KEY_U;
+-  is_hex_end = (event->keyval == GDK_KEY_space ||
+-                event->keyval == GDK_KEY_KP_Space ||
+-                event->keyval == GDK_KEY_Return ||
+-                event->keyval == GDK_KEY_ISO_Enter ||
+-                event->keyval == GDK_KEY_KP_Enter);
++  is_hex_start = FALSE;
++  is_hex_end = FALSE;
+   is_backspace = event->keyval == GDK_KEY_BackSpace;
+   is_escape = event->keyval == GDK_KEY_Escape;
+   hex_keyval = canonical_hex_keyval (event);
+-- 
+2.47.0
+

--- a/archlinuxcn/gtk3-lily/PKGBUILD
+++ b/archlinuxcn/gtk3-lily/PKGBUILD
@@ -65,11 +65,13 @@ source=(
   "git+https://gitlab.gnome.org/GNOME/gtk.git#tag=$pkgver"
   gtk-query-immodules-3.0.hook
   0001-Allow-disabling-legacy-Tracker-search.patch
-  0001-wayland-im-notify-wayland-after-set_cursor_location.patch)
+  0001-wayland-im-notify-wayland-after-set_cursor_location.patch
+  0001-inhibit-hex-check.patch)
 b2sums=('fdda77eebdc0b8e378f0258cb241eda4412b868d59ea1fd90815f459e925e6433f94c22a088d695b72fab99ecca827b370942bea47043debef4fab78e0e03dca'
         '8e6a3906126749c6d853f582e3802254cdbba099c6af7190ad576eff6ea5425404a72b1b36950a87e3afdac82295cfe246003172c3e0341a73bd931a36f3b407'
         'ae371c52f24d00153037622de12a7e0026223c50fcb4b83e88138e2fd8b69a27422dfc91dae3a83c24705c57370bc9d75de4228210041c10c55482443478e240'
-        '2718db7adc07ee2df86b6dacbfb7638217b2cb76c5f5acde4ce9bd7a4617989744326069670b6cc4e5aff59fac410db9b60db7f07dd2a2e36a40b7a3b0d2d8b9')
+        '2718db7adc07ee2df86b6dacbfb7638217b2cb76c5f5acde4ce9bd7a4617989744326069670b6cc4e5aff59fac410db9b60db7f07dd2a2e36a40b7a3b0d2d8b9'
+        '805b43b9be928362fc9e5ec1738bc9c069d2f3fc32c6d740aefdbab1f8cbd43a5d11aea8113cf9df613f203f6dd77ac250a1e3a6f2399848de58642f08ac0aac')
 
 prepare() {
   cd gtk
@@ -82,6 +84,7 @@ prepare() {
   # Don't try to use the old Tracker
   git apply -3 ../0001-Allow-disabling-legacy-Tracker-search.patch
   patch -Np1 -i ../0001-wayland-im-notify-wayland-after-set_cursor_location.patch
+  patch -Np1 -i ../0001-inhibit-hex-check.patch
 }
 
 build() {


### PR DESCRIPTION
The patch can be found at https://github.com/XeCycle/gtk/tree/drop-unicode-input.