### PR TITLE
Add AArch64 support for `libpasastro` package

### DIFF
--- a/archlinuxcn/libpasastro/PKGBUILD
+++ b/archlinuxcn/libpasastro/PKGBUILD
@@ -6,7 +6,7 @@ pkgver=1.4.3
 pkgrel=1
 _pkgver="v$pkgver"
 pkgdesc="Provide Pascal interface for standard astronomy libraries"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://github.com/pchev/libpasastro"
 license=('GPL-2.0-or-later')
 depends=('gcc-libs')
@@ -27,4 +27,3 @@ package() {
   cd "$srcdir/$pkgname"
   make install PREFIX="$pkgdir/usr"
 }
-


### PR DESCRIPTION
I have tested this updated PKGBUILD using `makepkg` and then `pacman -U` on armv8l. The package builds and installs successfully.

No changes are needed in order to add ARM support other than adding it to the `arch` array.