### PR TITLE
ecapture: do not strip symbol in makefile

### DIFF
--- a/archlinuxcn/ecapture/0001-fix-build.patch
+++ b/archlinuxcn/ecapture/0001-fix-build.patch
@@ -16,7 +16,7 @@ index 67ac96c..447a084 100644
  	CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/libpcap/ -lpcap -static' \
  	GOOS=linux GOARCH=$(GOARCH) CC=$(CMD_CC_PREFIX)$(CMD_CC) \
 -	$(CMD_GO) build -tags '$(TARGET_TAG),netgo' -ldflags "-w -s -X 'github.com/gojue/ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION_NUM):$(VERSION_FLAG)' -X 'github.com/gojue/ecapture/cli/cmd.ByteCodeFiles=$(BYTECODE_FILES)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
-+	$(CMD_GO) build -trimpath -buildmode=pie -mod=readonly -modcacherw -tags '$(TARGET_TAG),netgo' -ldflags "-w -s -X 'github.com/gojue/ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION_NUM):$(VERSION_FLAG)' -X 'github.com/gojue/ecapture/cli/cmd.ByteCodeFiles=$(BYTECODE_FILES)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
++	$(CMD_GO) build -trimpath -buildmode=pie -mod=readonly -modcacherw -tags '$(TARGET_TAG),netgo' -ldflags "-w -X 'github.com/gojue/ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION_NUM):$(VERSION_FLAG)' -X 'github.com/gojue/ecapture/cli/cmd.ByteCodeFiles=$(BYTECODE_FILES)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
  	$(CMD_FILE) $(OUT_BIN)
  endef
  


### PR DESCRIPTION
for symbols are available in the `-debug` package