### PR TITLE
clash-meta: remove `conflicts`

### DIFF
--- a/archlinuxcn/clash-meta/PKGBUILD
+++ b/archlinuxcn/clash-meta/PKGBUILD
@@ -2,14 +2,13 @@
 
 pkgname=clash-meta
 pkgver=1.19.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Another Clash Kernel by MetaCubeX"
 arch=('x86_64' 'aarch64' 'riscv64' 'loong64')
 url="https://github.com/MetaCubeX/Clash.Meta"
 license=("GPL3")
 depends=('glibc' 'clash-geoip')
 makedepends=('go')
-conflicts=(clash-meta)
 backup=('etc/clash-meta/config.yaml')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
         "clash-meta.service"


### PR DESCRIPTION
删除 clash-meta 的 conflicts 字段以避免如下情况。 （由  archlinuxcn tg群组用户 @IdeaPocket 报告。）

> 我自己整了个空包provide那些我觉得用不上的被依赖的包,之前我没用源里的clash-meta但是verge依赖Meta,就把meta加进去了,然后触发了冲突
> 这回想用回源里的meta后发生了冲突,不然要自己改PKGBUILD重新安装那个空包

ps: 直接改 AUR包不行，lilac会检测到有更新，然后用仓库的覆盖AUR的。