### PR TITLE
linux-clear: replace linux-clear-x64-v3 with linux-clear in package.list

### DIFF
--- a/archlinuxcn/linux-clear/lilac.yaml
+++ b/archlinuxcn/linux-clear/lilac.yaml
@@ -9,3 +9,5 @@ time_limit_hours: 1.5
 update_on:
   - source: aur
     aur: linux-clear
+  - source: manual
+    manual: 1

--- a/archlinuxcn/linux-clear/package.list
+++ b/archlinuxcn/linux-clear/package.list
@@ -1,2 +1,2 @@
-linux-clear-x64-v3
-linux-clear-x64-v3-headers
+linux-clear
+linux-clear-headers


### PR DESCRIPTION
The linux-clear-x64-v3 built in 2024 is still retained in the repository.