### PR TITLE
tela-icon-theme-git: disable debug in options

### DIFF
--- a/archlinuxcn/tela-icon-theme-git/PKGBUILD
+++ b/archlinuxcn/tela-icon-theme-git/PKGBUILD
@@ -9,7 +9,7 @@ arch=('any')
 url="https://github.com/vinceliuice/Tela-icon-theme"
 license=('GPL3')
 makedepends=('git')
-options=('!strip')
+options=('!strip' '!debug')
 
 source=("git+https://github.com/vinceliuice/Tela-icon-theme.git")
 


### PR DESCRIPTION
Debug symbols are unnecessary for this package.