### PR TITLE
fotema: add missing dependency openmpi

### DIFF
--- a/archlinuxcn/fotema/PKGBUILD
+++ b/archlinuxcn/fotema/PKGBUILD
@@ -14,6 +14,7 @@ depends=(
   'libshumate'
   'onnxruntime'
   'opencv'
+  'openmpi'
 )
 makedepends=(
   'cargo'

--- a/archlinuxcn/fotema/lilac.yaml
+++ b/archlinuxcn/fotema/lilac.yaml
@@ -1,8 +1,11 @@
 build_prefix: extra-x86_64
-pre_build_script: aur_pre_build(maintainers=['yochananmarqos'])
+pre_build_script: |
+  aur_pre_build(maintainers=['yochananmarqos'])
+  add_depends(['openmpi'])
 post_build: aur_post_build
 update_on:
   - source: aur
     aur: fotema
+
 maintainers:
   - github: roaldclark


### PR DESCRIPTION
otherwise would crash with could not load the library at `libonnxruntime.so`: DlOpen { desc: "libmpi.so.40: cannot open shared object file: No such file or directory" } when face detection is enabled