### PR TITLE
dufs: fix permissions of UNIX sockets

### DIFF
--- a/archlinuxcn/dufs/dufs.service
+++ b/archlinuxcn/dufs/dufs.service
@@ -8,6 +8,8 @@ Type=simple
 User=dufs
 Group=dufs
 ExecStart=/usr/bin/dufs --config /etc/dufs/config.yaml
+# Fix permissions of UNIX sockets
+ExecStartPost=/usr/bin/bash -c '/usr/bin/sleep 1; for file in /run/dufs/*; do if [ -S "$file" ]; then /usr/bin/chmod 0660 "$file"; fi; done'
 
 [Install]
 WantedBy=multi-user.target

--- a/archlinuxcn/dufs/dufs@.service
+++ b/archlinuxcn/dufs/dufs@.service
@@ -8,6 +8,8 @@ Type=simple
 User=dufs
 Group=dufs
 ExecStart=/usr/bin/dufs --config /etc/dufs/%i.yaml
+# Fix permissions of UNIX sockets
+ExecStartPost=/usr/bin/bash -c '/usr/bin/sleep 1; for file in /run/dufs/*; do if [ -S "$file" ]; then /usr/bin/chmod 0660 "$file"; fi; done'
 
 [Install]
 WantedBy=multi-user.target

--- a/archlinuxcn/dufs/lilac.yaml
+++ b/archlinuxcn/dufs/lilac.yaml
@@ -15,3 +15,5 @@ update_on:
     github: sigoden/dufs
     use_max_tag: true
     prefix: v
+  - source: manual
+    manual: 1


### PR DESCRIPTION
https://github.com/sigoden/dufs/issues/506

在服务启动后修正 socket 的权限。

```txt
puqns67@elaina ~> sudo systemctl restart dufs.service
puqns67@elaina ~> la /run/dufs
srwxr-xr-x - dufs dufs 2025/04/20 21:51:14 storage.socket
puqns67@elaina ~> paru -U dufs-0.43.0-3-x86_64.pkg.tar.zst
...
puqns67@elaina ~> sudo systemctl restart dufs.service
puqns67@elaina ~> la /run/dufs
srw-rw---- - dufs dufs 2025/04/20 21:51:46 storage.socket
```