### PR TITLE
rustdesk-server: new package

### DIFF
--- a/archlinuxcn/rustdesk-server/PKGBUILD
+++ b/archlinuxcn/rustdesk-server/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Puqns67 <me@puqns67.icu>
+
+pkgname='rustdesk-server'
+pkgver='1.1.14'
+pkgrel=4
+pkgdesc='RustDesk Server Program'
+arch=('x86_64')
+url='https://github.com/rustdesk/rustdesk-server'
+license=('AGPL-3.0-or-later')
+depends=('gcc-libs' 'glibc')
+makedepends=('git' 'rust')
+conflicts=("${pkgname}-bin")
+backup=("etc/default/${pkgname}-hbbr"
+        "etc/default/${pkgname}-hbbs")
+options=('!lto')
+
+source=("${pkgname}"::"git+${url}.git#tag=${pkgver}"
+        "${pkgname}-hbb_common"::"git+https://github.com/rustdesk/hbb_common.git"
+        "${pkgname}-sysusers.conf"
+        "${pkgname}-tmpfiles.conf"
+        "${pkgname}-hbbr.service"
+        "${pkgname}-hbbs.service"
+        "${pkgname}-hbbr.default"
+        "${pkgname}-hbbs.default")
+
+b2sums=('8518ca0011823539c2987ee8460cfba5aa1f21cfa06dd7822e81563f6dd7e6b01c47c7598f49166e597da67ba5084860d4dc1e16c811343980d9e12548605d38'
+        'SKIP'
+        '736e07c9f81ca791e1ca05a209eb7551d6b87250f12554dbeb13b46f98795a3bcc556fc9548d856223b10566729988485e0376022afb1b59a333ec03d3b47cea'
+        'ef24fd0191b6cb1e4a1919ea579f1568ceeccf58c562316990c5697c1a593d6e1bdaa780bde115a1f7bd6556c128b68515f5fb4e535c805a35b338fc3fca232a'
+        '566ca6b645602758cb1a5d52c5384352e49aefebc3537549c583ada52f3785e58759c42eccaef02db024085b52c84aada15f5c2809d3d1d836ec542dd3c99263'
+        '48441b4ecd6a48c4974d3113d9184b1de2b844a0b5e500750a7289a602b854e11ca625c1184f5776cd89160b1340c492846cc5d3b705ce28937500454f5e706f'
+        'b6233f341a96439bd651b191052c06fd3f5518f9d3c91a7a39df0050d199981de7ec2dd4e380b771f30b8b7fc10687f678352b25338dd3390b5cb408b22140fd'
+        'eb40517dbd14f51342651baf47b7e4acc8ca454b763efaa110d597243ea96c22bb3b28f3f168285e6ccb8f57584451ada2d0348ba7174ef0dd8a2ff5c0028b7a')
+
+prepare() {
+  export RUSTUP_TOOLCHAIN=stable
+
+  cd "${srcdir}/${pkgname}"
+
+  # Setup submodule
+  git submodule init
+  git config submodule.libs/hbb_common.url "${srcdir}/${pkgname}-hbb_common"
+  git -c protocol.file.allow=always submodule update
+
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+
+  cd "${srcdir}/${pkgname}"
+
+  cargo build --frozen --release --all-features
+}
+
+package() {
+  install -Dm755 "${srcdir}/${pkgname}/target/release/hbbr" "${pkgdir}/usr/bin/${pkgname}-hbbr"
+  install -Dm755 "${srcdir}/${pkgname}/target/release/hbbs" "${pkgdir}/usr/bin/${pkgname}-hbbs"
+  install -Dm755 "${srcdir}/${pkgname}/target/release/rustdesk-utils" "${pkgdir}/usr/bin/rustdesk-utils"
+
+  install -Dm644 "${srcdir}/${pkgname}-sysusers.conf" "${pkgdir}/usr/lib/sysusers.d/${pkgname}.conf"
+  install -Dm644 "${srcdir}/${pkgname}-tmpfiles.conf" "${pkgdir}/usr/lib/tmpfiles.d/${pkgname}.conf"
+
+  install -Dm644 "${srcdir}/${pkgname}-hbbr.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}-hbbr.service"
+  install -Dm644 "${srcdir}/${pkgname}-hbbs.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}-hbbs.service"
+
+  install -Dm644 "${srcdir}/${pkgname}-hbbr.default" "${pkgdir}/etc/default/${pkgname}-hbbr"
+  install -Dm644 "${srcdir}/${pkgname}-hbbs.default" "${pkgdir}/etc/default/${pkgname}-hbbs"
+}

--- a/archlinuxcn/rustdesk-server/lilac.yaml
+++ b/archlinuxcn/rustdesk-server/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: Puqns67
+
+build_prefix: extra-x86_64
+
+pre_build_script: |
+  update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+
+update_on:
+  - source: github
+    github: rustdesk/rustdesk-server
+    use_max_tag: true

--- a/archlinuxcn/rustdesk-server/rustdesk-server-hbbr.default
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-hbbr.default
@@ -1,0 +1,23 @@
+# Delay (in seconds) before downgrade check
+#DOWNGRADE_START_CHECK=
+
+# Threshold of downgrade check (bit/ms)
+#DOWNGRADE_THRESHOLD=
+
+# If set force the use of a specific key, if set to "_" force the use of any key
+#KEY=
+
+# Speed limit (in Mb/s)
+#LIMIT_SPEED=
+
+# Listening port (21116 for hbbs, 21117 for hbbr)
+#PORT=
+
+# Set debug level (error|warn|info|debug|trace)
+#RUST_LOG=
+
+# Max bandwidth for a single connection (in Mb/s)
+#SINGLE_BANDWIDTH=
+
+# Max total bandwidth (in Mb/s)
+#TOTAL_BANDWIDTH=

--- a/archlinuxcn/rustdesk-server/rustdesk-server-hbbr.service
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-hbbr.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=RustDesk Relay Server
+Requires=network.target
+
+[Service]
+User=rustdesk-server
+Group=rustdesk-server
+WorkingDirectory=~
+EnvironmentFile=-/etc/default/rustdesk-server-hbbr
+ExecStart=/usr/bin/rustdesk-server-hbbr
+Restart=always
+RestartSec=10
+LimitNOFILE=ininity
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinuxcn/rustdesk-server/rustdesk-server-hbbs.default
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-hbbs.default
@@ -1,0 +1,17 @@
+# If set to "Y" disallows direct peer connection
+#ALWAYS_USE_RELAY=
+
+# Path for database file
+#DB_URL=
+
+# If set force the use of a specific key, if set to "_" force the use of any key
+#KEY=
+
+# Listening port (21116 for hbbs, 21117 for hbbr)
+#PORT=
+
+# IP address/DNS name of the machines running hbbr (separated by comma)
+#RELAY=
+
+# Set debug level (error|warn|info|debug|trace)
+#RUST_LOG=

--- a/archlinuxcn/rustdesk-server/rustdesk-server-hbbs.service
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-hbbs.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=RustDesk ID/Rendezvous Server
+Requires=network.target
+
+[Service]
+User=rustdesk-server
+Group=rustdesk-server
+WorkingDirectory=~
+EnvironmentFile=-/etc/default/rustdesk-server-hbbs
+ExecStart=/usr/bin/rustdesk-server-hbbs
+Restart=always
+RestartSec=10
+LimitNOFILE=ininity
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinuxcn/rustdesk-server/rustdesk-server-sysusers.conf
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-sysusers.conf
@@ -1,0 +1,1 @@
+u rustdesk-server - "RustDesk Server" /var/lib/rustdesk-server

--- a/archlinuxcn/rustdesk-server/rustdesk-server-tmpfiles.conf
+++ b/archlinuxcn/rustdesk-server/rustdesk-server-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/lib/rustdesk-server 0750 rustdesk-server rustdesk-server -


### PR DESCRIPTION
打包 [Rustdesk](https://github.com/rustdesk/rustdesk) 的[服务端](https://github.com/rustdesk/rustdesk-server)，作为仓库中已有的 Rustdesk 的补充。