### PR TITLE
harden aur_pre_build (#2228)

### DIFF
--- a/archlinuxcn/abcde/lilac.yaml
+++ b/archlinuxcn/abcde/lilac.yaml
@@ -6,7 +6,7 @@ build_prefix: extra-x86_64
 repo_depends:
   - cd-discid
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['FabioLolix'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/cd-discid/lilac.yaml
+++ b/archlinuxcn/cd-discid/lilac.yaml
@@ -3,7 +3,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['FabioLolix'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/dracut-ukify/lilac.yaml
+++ b/archlinuxcn/dracut-ukify/lilac.yaml
@@ -1,7 +1,7 @@
 maintainers:
   - github: Kimiblock
 
-pre_build_script: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['Prototik'])
 post_build_script: |
   git_pkgbuild_commit()
 #  update_aur_repo()

--- a/archlinuxcn/go-for-it-git/lilac.py
+++ b/archlinuxcn/go-for-it-git/lilac.py
@@ -7,7 +7,7 @@ from lilaclib import *
 
 def pre_build():
     run_cmd(["rm", "-rf", "go-for-it-git"])
-    aur_pre_build()
+    aur_pre_build(maintainers=['btd1337'])
     for line in edit_file('PKGBUILD'):
         if line.startswith('makedepends'):
             line = "makedepends=('vala' 'git' 'cmake' 'intltool')"

--- a/archlinuxcn/java-service-wrapper/lilac.py
+++ b/archlinuxcn/java-service-wrapper/lilac.py
@@ -12,7 +12,7 @@ from lilaclib import *
 #post_build = aur_post_build
 
 def pre_build():
-    aur_pre_build()
+    aur_pre_build(maintainers=['Salama'])
     for line in edit_file('PKGBUILD'):
         if "java-environment>=" in line:
             line = line.replace("java-environment>=8","jdk8-openjdk")

--- a/archlinuxcn/netease-cloud-music-gtk4/lilac.yaml
+++ b/archlinuxcn/netease-cloud-music-gtk4/lilac.yaml
@@ -4,7 +4,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['AutoUpdateBot','tkit'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/obfs4proxy/lilac.py
+++ b/archlinuxcn/obfs4proxy/lilac.py
@@ -8,7 +8,8 @@
 from lilaclib import *
 
 build_prefix = 'extra-x86_64'
-pre_build = aur_pre_build
+def pre_build():
+    aur_pre_build(maintainers=['aminvakil'])
 post_build = aur_post_build
 
 if __name__ == '__main__':

--- a/archlinuxcn/pacman-pstatus/lilac.yaml
+++ b/archlinuxcn/pacman-pstatus/lilac.yaml
@@ -6,7 +6,7 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['renyuneyun'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/python-pdm-pep517/lilac.yaml
+++ b/archlinuxcn/python-pdm-pep517/lilac.yaml
@@ -1,4 +1,4 @@
-pre_build_script: aur_pre_build()
+pre_build_script: aur_pre_build(maintainers=['flyin1501','ilovemikael'])
 
 post_build: aur_post_build
 

--- a/archlinuxcn/python-pygresql/lilac.py
+++ b/archlinuxcn/python-pygresql/lilac.py
@@ -5,7 +5,7 @@ from lilaclib import *
 build_prefix = "extra-x86_64"
 
 def pre_build():
-  aur_pre_build()
+  aur_pre_build(maintainers=['beeender'])
 
 def post_build():
   aur_post_build()

--- a/archlinuxcn/sssm/lilac.yaml
+++ b/archlinuxcn/sssm/lilac.yaml
@@ -4,5 +4,5 @@ build_prefix: multilib
 update_on:
   - source: aur
     aur: sssm
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['Infernio'])
 post_build: aur_post_build

--- a/archlinuxcn/way-secure/lilac.yaml
+++ b/archlinuxcn/way-secure/lilac.yaml
@@ -1,5 +1,5 @@
 build_prefix: extra-x86_64
-pre_build: aur_pre_build
+pre_build_script: aur_pre_build(maintainers=['Kimiblock'])
 post_build: aur_post_build
 update_on:
   - source: aur


### PR DESCRIPTION
Fix #2228

用脚本批量了添加现有 AUR Maintainer 和 CoMaintainers

- 若 Last Packager 与 Maintainer + CoMaintainers 不同，lilac 会拒绝，所以此时也添加到maintainers中

```bash
grep -rl "aur_pre_build" archlinuxcn alarmcn | while read -r file; do
  if grep "aur_pre_build" "$file" |\
     grep -v "maintainers=" |\
     grep -v "^#" |\
     grep -vq "from lilaclib import aur_pre_build"
  then
    echo "$file"
  fi
done
```
