### PR TITLE
zen-browser: remove update_aur_repo

### DIFF
--- a/archlinuxcn/zen-browser/lilac.yaml
+++ b/archlinuxcn/zen-browser/lilac.yaml
@@ -1,9 +1,7 @@
 maintainers:
 - github: heavysink
 
-post_build_script: |
-  git_pkgbuild_commit()
-  update_aur_repo()
+post_build_script: git_pkgbuild_commit()
 
 update_on:
 - source: github


### PR DESCRIPTION
由于此包已由 @heavysink 维护，但 AUR 中的包还在我的名下，之前有问过 @heavysink 是否可以一起维护 AUR 中的包，没有得到回应，现打算弃置掉 AUR 中的包，故移除自动更新 AUR 的操作。我将在合并后从共同维护者中清除 lilac，并弃置此包。