### PR TITLE
Remove redundant optdepends and bin links to avoid conflicts

### DIFF
--- a/archlinuxcn/zen-browser-portable/PKGBUILD
+++ b/archlinuxcn/zen-browser-portable/PKGBUILD
@@ -75,4 +75,4 @@ NoDisplay=true''' >"${pkgdir}/usr/share/applications/zen-browser.desktop"
 }
 sha256sums=('e79bba18a1cc0997cab92a1d6cb7d9c8c6c5263de5b1f350b2ab45b1e8ce5d75'
             'b1df66c4246e6584efef74f5c0ae74b7c51c32823bf28bd92a3ef3c938dcaa09'
-            'b016d614f68dd6f51e9b31344bd81befae1de0d2b4f93d9ee4c1ef5c40aff350')
+            'b1366506d4df221581e67544edd00728b9793da1cb8609beec3cf138d4a75eaf')

--- a/archlinuxcn/zen-browser-portable/PKGBUILD
+++ b/archlinuxcn/zen-browser-portable/PKGBUILD
@@ -52,9 +52,6 @@ function package() {
 	rm "${pkgdir}/usr/bin"/*
 	install -Dm755 \
 		"${srcdir}/start.sh" \
-		"${pkgdir}/usr/bin/zen"
-	install -Dm755 \
-		"${srcdir}/start.sh" \
 		"${pkgdir}/usr/bin/zen-browser"
 	install -Dm644 \
 		"${srcdir}/desktop.file" \

--- a/archlinuxcn/zen-browser-portable/PKGBUILD
+++ b/archlinuxcn/zen-browser-portable/PKGBUILD
@@ -15,11 +15,7 @@ depends=(
 	"portable"
 )
 
-optdepends=(
-	"zen-browser-i18n-zh-cn: Language pack for Zen Browser (zh-CN)"
-	"zen-browser-i18n-zh-tw: Language pack for Zen Browser (zh-TW)"
-	"zen-browser-i18n-ja: Language pack for Zen Browser (ja)"
-)
+optdepends=()
 
 provides=("zen-browser=${pkgver}")
 conflicts=(zen-browser)


### PR DESCRIPTION
I reverted to the previous changes and noticed that the icon missing issue no longer appears. Therefore, I gave up on modifying that problem.
Now, I have only removed the `optdepends` content (which originally didn’t exist, and adding it seems to cause a minor cycle dependency).
Deleted the redundant /bin link (I think keeping just one is sufficient for simplicity, and the name “zen” is prone to conflicts),
And removed the SHA256 of one file.