### PR TITLE
ceccomp: apply new configure features

### DIFF
--- a/alarmcn/ceccomp/PKGBUILD
+++ b/alarmcn/ceccomp/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: dbgbgtf <dudududumaxver@outlook.com>
 # Maintainer: RocketDev <ma2014119@outlook.com>
 pkgname=ceccomp
-pkgver=3.1
-pkgrel=2
+pkgver=3.2
+pkgrel=1
 pkgdesc="A C-based seccomp analysis tool"
 arch=(x86_64 aarch64)
 url="https://github.com/dbgbgtf1/Ceccomp"
@@ -20,7 +20,7 @@ makedepends=(
 )
 
 source=("$pkgname"::git+https://github.com/dbgbgtf1/Ceccomp.git#tag=v${pkgver}?signed)
-b2sums=('e4f6106a0a141f8e617abf3d1502dad1eac2764c7ee9b8aa714c5ea5a1cf62c5a9a283195e5a693628e9c5f8dad23137aa21770fe278b6008a99674c03292f28')
+b2sums=('6b2296ed959e61e9cd77d95143b45af6c3762d68ff18c88d227d7685175cd6ef17ef228e0cdf40031f6ccdc0f9d0142d84d9aa7b18e5b94f3ac4c6d9626c0fae')
 
 validpgpkeys=(
     '0816A179BB09248F30468BD6542A0969B5CEDCDB' # dbgbgtf1 <dudududumaxver@outlook.com>
@@ -30,9 +30,8 @@ validpgpkeys=(
 build() {
     # lilac always has clean root build
     cd "$srcdir/$pkgname"
-    ./configure --prefix="$pkgdir/usr"
-    # force program to load locale in system
-    make LOCALE_DIR=/usr/share/locale
+    ./configure --destdir="$pkgdir" --packager="Arch Linux CN"
+    make
 }
 
 package() {

--- a/archlinuxcn/ceccomp/PKGBUILD
+++ b/archlinuxcn/ceccomp/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: dbgbgtf <dudududumaxver@outlook.com>
 # Maintainer: RocketDev <ma2014119@outlook.com>
 pkgname=ceccomp
-pkgver=3.1
-pkgrel=2
+pkgver=3.2
+pkgrel=1
 pkgdesc="A C-based seccomp analysis tool"
 arch=(x86_64 aarch64)
 url="https://github.com/dbgbgtf1/Ceccomp"
@@ -20,7 +20,7 @@ makedepends=(
 )
 
 source=("$pkgname"::git+https://github.com/dbgbgtf1/Ceccomp.git#tag=v${pkgver}?signed)
-b2sums=('e4f6106a0a141f8e617abf3d1502dad1eac2764c7ee9b8aa714c5ea5a1cf62c5a9a283195e5a693628e9c5f8dad23137aa21770fe278b6008a99674c03292f28')
+b2sums=('6b2296ed959e61e9cd77d95143b45af6c3762d68ff18c88d227d7685175cd6ef17ef228e0cdf40031f6ccdc0f9d0142d84d9aa7b18e5b94f3ac4c6d9626c0fae')
 
 validpgpkeys=(
     '0816A179BB09248F30468BD6542A0969B5CEDCDB' # dbgbgtf1 <dudududumaxver@outlook.com>
@@ -30,9 +30,8 @@ validpgpkeys=(
 build() {
     # lilac always has clean root build
     cd "$srcdir/$pkgname"
-    ./configure --prefix="$pkgdir/usr"
-    # force program to load locale in system
-    make LOCALE_DIR=/usr/share/locale
+    ./configure --destdir="$pkgdir" --packager="Arch Linux CN"
+    make
 }
 
 package() {


### PR DESCRIPTION
最新的版本中更新了`configure`，可以把丑陋的workaround去掉了