### PR TITLE
chore(rime-pinyin-moegirl): sync with AUR

### DIFF
--- a/archlinuxcn/fcitx5-pinyin-moegirl/lilac.yaml
+++ b/archlinuxcn/fcitx5-pinyin-moegirl/lilac.yaml
@@ -4,11 +4,11 @@ maintainers:
 
 build_prefix: extra-x86_64
 
-post_build: git_pkgbuild_commit
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
 
 update_on:
   - source: github
     github: outloudvi/mw2fcitx
     use_max_tag: true
-  - source: manual
-    manual: 2


### PR DESCRIPTION
我希望AUR上的[`rime-pinyin-moegirl`](https://aur.archlinux.org/packages/rime-pinyin-moegirl)包也能自动更新，且已将[lilac](https://aur.archlinux.org/account/lilac)添加为共同维护者。这样应该是正确的吧？