### PR TITLE
Remove fvm from `repo_makedepends` to use extra/fvm

### DIFF
--- a/archlinuxcn/c001apk-flutter-git/lilac.yaml
+++ b/archlinuxcn/c001apk-flutter-git/lilac.yaml
@@ -10,9 +10,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: Integral-Tech/c001apk-flutter

--- a/archlinuxcn/ciyue/lilac.yaml
+++ b/archlinuxcn/ciyue/lilac.yaml
@@ -7,9 +7,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: mumu-lhl/Ciyue

--- a/archlinuxcn/danxi-git/lilac.yaml
+++ b/archlinuxcn/danxi-git/lilac.yaml
@@ -10,9 +10,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: DanXi-Dev/DanXi

--- a/archlinuxcn/danxi/lilac.yaml
+++ b/archlinuxcn/danxi/lilac.yaml
@@ -7,9 +7,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: DanXi-Dev/DanXi

--- a/archlinuxcn/kazumi/lilac.yaml
+++ b/archlinuxcn/kazumi/lilac.yaml
@@ -7,9 +7,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: Predidit/Kazumi

--- a/archlinuxcn/piliplus/lilac.yaml
+++ b/archlinuxcn/piliplus/lilac.yaml
@@ -7,9 +7,6 @@ post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()
 
-repo_makedepends:
-  - fvm
-
 update_on:
   - source: github
     github: bggRGjQaUbCoE/PiliPlus


### PR DESCRIPTION
Remove fvm from `repo_makedepends` as fvm is now available in [the official repository](https://archlinux.org/packages/extra/x86_64/fvm).