### PR TITLE
fix(v2ray-rules-dat): add missing `pre_build_script`

### DIFF
--- a/archlinuxcn/v2ray-rules-dat/lilac.yaml
+++ b/archlinuxcn/v2ray-rules-dat/lilac.yaml
@@ -3,8 +3,9 @@ maintainers:
     email: DeepChirp@outlook.com
   - github: hour-keeper
 
-build_prefix: extra-x86_64
+build_prefix: archlinuxcn-x86_64
 
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
 post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()


### PR DESCRIPTION
看起来我遗漏了`pre_build_script`的`update_pkgver_and_pkgrel`，导致对应的包无法正常更新。