### PR TITLE
addpkg: rustnet

### DIFF
--- a/archlinuxcn/rustnet/PKGBUILD
+++ b/archlinuxcn/rustnet/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=rustnet
 _pkgname=${pkgname%}
 _reponame=${pkgname%}
 pkgver=0.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Real-time network monitoring TUI with process identification via eBPF and deep packet inspection"
 arch=('x86_64' 'armv7h' 'aarch64')
 _author=domcyrus
@@ -71,5 +71,5 @@ package() {
     cd "$srcdir/$pkgname-$pkgver"
 
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$_pkgname"
-    install -Dm644 "${srcdir}/rustnet-setcap.hook" "${pkgdir}/usr/share/${pkgname}/hooks/rustnet-setcap.hook"
+    install -Dm644 -t "$pkgdir/usr/share/$_pkgname/hooks/" "$srcdir/rustnet-setcap.hook"
 }

--- a/archlinuxcn/rustnet/PKGBUILD
+++ b/archlinuxcn/rustnet/PKGBUILD
@@ -14,7 +14,6 @@ depends=('libpcap' 'libelf' 'zlib' 'gcc-libs' 'glibc')
 makedepends=('git' 'cargo' 'pkgconf' 'clang' 'llvm' 'lld' 'libbpf')
 provides=(${pkgname%})
 conflicts=("${pkgname%}-git" "${pkgname%}-bin")
-options=(strip)
 install=$_pkgname.install
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz"
         "rustnet-setcap.hook")

--- a/archlinuxcn/rustnet/PKGBUILD
+++ b/archlinuxcn/rustnet/PKGBUILD
@@ -14,10 +14,12 @@ depends=('libpcap' 'libelf' 'zlib' 'gcc-libs' 'glibc')
 makedepends=('git' 'cargo' 'pkgconf' 'clang' 'llvm' 'lld' 'libbpf')
 provides=(${pkgname%})
 conflicts=("${pkgname%}-git" "${pkgname%}-bin")
-options=(!debug strip)
+options=(strip)
 install=$_pkgname.install
-source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
-sha256sums=('389afa61c1d4b2b2d6849617a0940ed2b34106961ac223309bfa52753e59a8ef')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz"
+        "rustnet-setcap.hook")
+sha256sums=('389afa61c1d4b2b2d6849617a0940ed2b34106961ac223309bfa52753e59a8ef'
+            'b14ba212f2a589ca327a2e59563a4fdd3787c022baf43b6dc249b03814757cc4')
 
 prepare() {
     cd "$srcdir/$pkgname-$pkgver"
@@ -70,4 +72,5 @@ package() {
     cd "$srcdir/$pkgname-$pkgver"
 
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$_pkgname"
+    install -Dm644 "${srcdir}/rustnet-setcap.hook" "${pkgdir}/usr/share/${pkgname}/hooks/rustnet-setcap.hook"
 }

--- a/archlinuxcn/rustnet/PKGBUILD
+++ b/archlinuxcn/rustnet/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: DeepChirp <DeepChirp@outlook.com>
+
+pkgname=rustnet
+_pkgname=${pkgname%}
+_reponame=${pkgname%}
+pkgver=0.11.0
+pkgrel=3
+pkgdesc="Real-time network monitoring TUI with process identification via eBPF and deep packet inspection"
+arch=('x86_64' 'armv7h' 'aarch64')
+_author=domcyrus
+url="https://github.com/${_author}/${_reponame}"
+license=('Apache-2.0')
+depends=('libpcap' 'libelf' 'zlib' 'gcc-libs' 'glibc')
+makedepends=('git' 'cargo' 'pkgconf' 'clang' 'llvm' 'lld' 'libbpf')
+provides=(${pkgname%})
+conflicts=("${pkgname%}-git" "${pkgname%}-bin")
+options=(!debug strip)
+install=$_pkgname.install
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('389afa61c1d4b2b2d6849617a0940ed2b34106961ac223309bfa52753e59a8ef')
+
+prepare() {
+    cd "$srcdir/$pkgname-$pkgver"
+
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "$srcdir/$pkgname-$pkgver"
+
+    export RUSTUP_TOOLCHAIN=stable
+
+    # https://github.com/briansmith/ring/issues/1444#issuecomment-1763272308
+    # So we use Clang instead of GCC.
+    export CC="$(command -v clang)"
+    export AR="$(command -v llvm-ar)"
+    export NM="$(command -v llvm-nm)"
+    export RANLIB="$(command -v llvm-ranlib)"
+    _LD_LLD="$(command -v ld.lld)"
+
+    export RUSTFLAGS="-Clinker=$CC -Clink-arg=-fuse-ld=${_LD_LLD}"
+    export RUSTDOCFLAGS="$RUSTFLAGS"
+
+    export CARGO_PROFILE_RELEASE_LTO=thin
+    export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+    # Use ebpf for better performance
+    CFLAGS='-flto=auto' cargo build --frozen --release --features ebpf
+}
+
+check() {
+    cd "$srcdir/$pkgname-$pkgver"
+
+    export RUSTUP_TOOLCHAIN=stable
+    export CC="$(command -v clang)"
+    export AR="$(command -v llvm-ar)"
+    export NM="$(command -v llvm-nm)"
+    export RANLIB="$(command -v llvm-ranlib)"
+    _LD_LLD="$(command -v ld.lld)"
+
+    export RUSTFLAGS="-Clinker=$CC -Clink-arg=-fuse-ld=${_LD_LLD}"
+    export RUSTDOCFLAGS="$RUSTFLAGS"
+
+    export CARGO_PROFILE_RELEASE_LTO=thin
+    export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+    CFLAGS='-flto=auto' cargo test --frozen --release --features ebpf
+}
+
+package() {
+    cd "$srcdir/$pkgname-$pkgver"
+
+    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$_pkgname"
+}

--- a/archlinuxcn/rustnet/lilac.yaml
+++ b/archlinuxcn/rustnet/lilac.yaml
@@ -1,0 +1,15 @@
+maintainers:
+  - github: DeepChirp
+    email: DeepChirp@outlook.com
+
+build_prefix: extra-x86_64
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver.lstrip('v'))
+post_build_script: |
+  git_pkgbuild_commit()
+  update_aur_repo()
+
+update_on:
+  - source: github
+    github: domcyrus/rustnet
+    use_max_tag: true

--- a/archlinuxcn/rustnet/lilac.yaml
+++ b/archlinuxcn/rustnet/lilac.yaml
@@ -12,4 +12,4 @@ post_build_script: |
 update_on:
   - source: github
     github: domcyrus/rustnet
-    use_max_tag: true
+    use_latest_release: true

--- a/archlinuxcn/rustnet/rustnet-setcap.hook
+++ b/archlinuxcn/rustnet/rustnet-setcap.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = usr/bin/rustnet
+
+[Action]
+Description = Reapplying capabilities for RustNet
+When = PostTransaction
+Exec = /usr/bin/setcap 'cap_net_raw,cap_net_admin,cap_sys_admin+eip' /usr/bin/rustnet

--- a/archlinuxcn/rustnet/rustnet.install
+++ b/archlinuxcn/rustnet/rustnet.install
@@ -1,0 +1,9 @@
+post_install() {
+  printf "To run \"rustnet\" without sudo, you may grant Linux capabilities to the binary.\n"
+  printf "You can run following command as root:\n"
+  printf "  setcap 'cap_net_raw,cap_net_admin,cap_sys_admin+eip' /usr/bin/rustnet\n"
+}
+
+post_upgrade() {
+  post_install
+}

--- a/archlinuxcn/rustnet/rustnet.install
+++ b/archlinuxcn/rustnet/rustnet.install
@@ -1,9 +1,6 @@
 post_install() {
-  printf "To run \"rustnet\" without sudo, you may grant Linux capabilities to the binary.\n"
-  printf "You can run following command as root:\n"
-  printf "  setcap 'cap_net_raw,cap_net_admin,cap_sys_admin+eip' /usr/bin/rustnet\n"
-}
-
-post_upgrade() {
-  post_install
+  printf 'To allow running "rustnet" without sudo, you can enable the optional pacman hook:\n'
+  printf '  sudo ln -s /usr/share/rustnet/hooks/rustnet-setcap.hook /etc/pacman.d/hooks/\n'
+  printf 'Note: This hook grants Linux capabilities (cap_net_raw, cap_net_admin, cap_sys_admin).\n'
+  printf 'Granting cap_sys_admin is highly privileged; enable only if you understand the risk.\n'
 }


### PR DESCRIPTION
[RustNet](https://github.com/domcyrus/rustnet)仓库目前共有1.2k个star，且采用Apache-2.0许可证，我想应该有资格被加入这个仓库吧。

AUR上虽然有[rustnet-bin](https://aur.archlinux.org/packages/rustnet-bin)，但其依赖`libpcap.so.0.8`。目前该包的方法是创建软链接。不过我觉得可能不太好，因此还是选择直接从源代码构建。

本地构建看起来没有问题，不过会出现警告：`软件包含有对 $srcdir 的引用`，我不知道如何消除🤣。

<details>
<summary>
使用`namcap`的检查结果
</summary>

```bash
PKGBUILD (rustnet) I: Missing Contributor tag
rustnet I: Soname 'libgcc_s.so=1-64' is not specified as provides by gcc-libs yet (needed in files ['usr/bin/rustnet'])
rustnet I: Soname 'ld-linux-x86-64.so=2-64' is not specified as provides by glibc yet (needed in files ['usr/bin/rustnet'])
rustnet I: Soname 'libc.so=6-64' is not specified as provides by glibc yet (needed in files ['usr/bin/rustnet'])
rustnet I: Soname 'libm.so=6-64' is not specified as provides by glibc yet (needed in files ['usr/bin/rustnet'])
rustnet I: Soname 'libelf.so=1-64' is not specified as provides by libelf yet (needed in files ['usr/bin/rustnet'])
rustnet I: Link-level dependence (gcc-libs) in file ['usr/lib/libgcc_s.so.1']
rustnet I: Link-level dependence (glibc) in file ['usr/lib/libc.so.6', 'usr/lib/libm.so.6', 'usr/lib/ld-linux-x86-64.so.2']
rustnet I: Link-level dependence (libelf) in file ['usr/lib/libelf.so.1']
rustnet I: Link-level dependence (libpcap) in file ['usr/lib/libpcap.so.1']
rustnet I: Link-level dependence (zlib) in file ['usr/lib/libz.so.1']
rustnet I: Soname dependency 'libpcap.so=1-64' provided by libpcap detected and not included (needed in files ['usr/bin/rustnet'])
rustnet I: Soname dependency 'libz.so=1-64' provided by zlib detected and not included (needed in files ['usr/bin/rustnet'])
rustnet I: Soname depends as namcap sees them: depends=(gcc-libs glibc libelf libpcap.so=1-64 libz.so=1-64)
rustnet I: Provides as namcap sees them: provides=()
rustnet W: Unused shared library '/usr/lib64/ld-linux-x86-64.so.2' by file ('usr/bin/rustnet')
rustnet I: Dependency zlib detected and satisfied (libraries ['usr/lib/libz.so.1'] needed in files ['usr/bin/rustnet'])
rustnet I: Dependency glibc detected and satisfied (libraries ['usr/lib/libc.so.6', 'usr/lib/libm.so.6', 'usr/lib/ld-linux-x86-64.so.2'] needed in files ['usr/bin/rustnet'])
rustnet I: Dependency libpcap detected and satisfied (libraries ['usr/lib/libpcap.so.1'] needed in files ['usr/bin/rustnet'])
rustnet I: Dependency libelf detected and satisfied (libraries ['usr/lib/libelf.so.1'] needed in files ['usr/bin/rustnet'])
rustnet I: Dependency gcc-libs detected and satisfied (libraries ['usr/lib/libgcc_s.so.1'] needed in files ['usr/bin/rustnet'])
rustnet I: Depends as namcap sees them: depends=(zlib glibc libpcap libelf gcc-libs)
```

</details>

默认启用了`ebpf`，因其性能更好。