### PR TITLE
maa-assistant-arknights: fix cuda build

### DIFF
--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -29,6 +29,8 @@ if ((WITH_CUDA)); then
 fi
 
 prepare() {
+    sed -e 's/35 50 52 60 61 70//g;' -i "${srcdir}/FastDeploy-${_fastdeploy_ref}/cmake/cuda.cmake"
+
     cd "${srcdir}/MaaAssistantArknights-${_pkgver}"
 
     sed -e '/^find_package(fast/s/^/# /;' \


### PR DESCRIPTION
NVCC dropped support for old arch recently