### PR TITLE
chore: Update email addresses and add maintainer

### DIFF
--- a/archlinuxcn/rustnet/PKGBUILD
+++ b/archlinuxcn/rustnet/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: DeepChirp <DeepChirp@outlook.com>
+# Maintainer: lilydjwg <lilydjwg@gmail.com>
 
 pkgname=rustnet
 _pkgname=${pkgname%}

--- a/archlinuxcn/rustnet/lilac.yaml
+++ b/archlinuxcn/rustnet/lilac.yaml
@@ -1,6 +1,6 @@
 maintainers:
   - github: DeepChirp
-    email: DeepChirp@outlook.com
+    email: deepchirp@archlinuxcn.org
   - github: lilydjwg
 
 build_prefix: extra-x86_64

--- a/archlinuxcn/v2ray-rules-dat/PKGBUILD
+++ b/archlinuxcn/v2ray-rules-dat/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: DeepChirp <DeepChirp@outlook.com>
 # Maintainer: hour-keeper <lok-ation@outlook.com>
+# Contributor: lilydjwg <lilydjwg@gmail.com>
 # Contributor: Zenvie <134689569+Zenvie@users.noreply.github.com>
 # Contributor: Felix Yan <felixonmars@archlinux.org>
 

--- a/archlinuxcn/v2ray-rules-dat/lilac.yaml
+++ b/archlinuxcn/v2ray-rules-dat/lilac.yaml
@@ -1,6 +1,6 @@
 maintainers:
   - github: DeepChirp
-    email: DeepChirp@outlook.com
+    email: deepchirp@archlinuxcn.org
   - github: hour-keeper
 
 build_prefix: extra-x86_64


### PR DESCRIPTION
- Add maintainer and contributor to reflect the current situation.
- Change my email address to `archlinuxcn.org`.