### PR TITLE
Update nucleus-gtk4-git PKGBUILD

### DIFF
--- a/archlinuxcn/nucleus-gtk4-git/PKGBUILD
+++ b/archlinuxcn/nucleus-gtk4-git/PKGBUILD
@@ -13,8 +13,8 @@ url="https://codeberg.org/lo-vely/nucleus"
 license=('GPL-3.0-or-later')
 depends=('gtk4' 'libadwaita' 'python-gobject' 'python')
 makedepends=('blueprint-compiler' 'git' 'meson' 'ninja')
-provides=("${_pkgname}")
-conflicts=("${_pkgname}")
+provides=("${_pkgname}" "${_appname}")
+conflicts=("${_pkgname}" "${_appname}")
 source=("git+$url.git")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Because a conflict was found between the nucleus-gtk4-git and the nucleus package, it has been fixed. Thanks to Misaka13514 for the help and suggestions.