### PR TITLE
goldendict-ng: add `hunspell-dictionary` as optdepends

### DIFF
--- a/archlinuxcn/goldendict-ng/PKGBUILD
+++ b/archlinuxcn/goldendict-ng/PKGBUILD
@@ -27,6 +27,7 @@ depends=(
 	'qt6-speech'
 	'qt6-5compat'
 )
+optdepends=('hunspell-dictionary: Dictionary files for Hunspell support')
 makedepends=('cmake' 'qt6-tools')
 conflicts=('goldendict')
 provides=('goldendict')


### PR DESCRIPTION
The official repository provides quite a few Hunspell dictionary packages (for example, [`hunspell-en_us`](https://archlinux.org/packages/extra/any/hunspell-en_us/)), and GoldenDict-NG can use them directly. Perhaps they could be added as optional dependencies?