### PR TITLE
sing-box-alpha: add optdepends

### DIFF
--- a/archlinuxcn/sing-box-alpha/PKGBUILD
+++ b/archlinuxcn/sing-box-alpha/PKGBUILD
@@ -13,6 +13,8 @@ url='https://sing-box.sagernet.org/'
 license=('custom:GPL-3.0-or-later WITH name use or association addition')
 
 depends=('glibc')
+optdepends=('sing-geosite-rule-set: GeoSite rule sets'
+            'sing-geoip-rule-set: GeoIP rule sets')
 makedepends=('go' 'clang' 'lld')
 
 source=("${_pkgname}-${_pkgver}.tar.gz::https://github.com/SagerNet/sing-box/archive/v${_pkgver}.tar.gz")


### PR DESCRIPTION
`sing-box` can use `sing-geosite` and `sing-geoip` to handle routing rules. Therefore, perhaps it would be better to add them as optional dependencies, just like the `sing-box` package?