### PR TITLE
mpv-git: disable aaudio and audiotrack features

### DIFF
--- a/archlinuxcn/mpv-git/PKGBUILD
+++ b/archlinuxcn/mpv-git/PKGBUILD
@@ -137,6 +137,8 @@ build() {
         '-Dopensles=disabled' # Android
         '-Degl-android=disabled' # Android
         '-Dandroid-media-ndk=disabled' # Android
+        '-Daaudio=disabled' # Android
+        '-Daudiotrack=disabled' # Android
         '-Doss-audio=disabled' # Not Linux
     )
     


### PR DESCRIPTION
These are Android audio outputs, and became meson options in https://github.com/mpv-player/mpv/pull/12261.