### PR TITLE
Add eden-git

### DIFF
--- a/archlinuxcn/eden-git/PKGBUILD
+++ b/archlinuxcn/eden-git/PKGBUILD
@@ -1,0 +1,87 @@
+# Maintainer: sukanka <su975853527 [at] gmail [dot] com>
+_pkgname=eden
+pkgname=${_pkgname,,}-git
+_cmd=yuzu
+pkgver=0.0.4.rc3.r71.gdf3b940
+pkgrel=1
+epoch=2
+_tzdb_ver=121125
+pkgdesc="Nintendo Switch emulator forked from yuzu"
+arch=(x86_64)
+url=https://git.eden-emu.dev/eden-emu/eden
+license=(GPL-3.0-or-later)
+provides=('eden')
+depends=('boost-libs' 'hicolor-icon-theme' 'sdl2' 'qt6-base' 'qt6-webengine' 'fmt' 'opus' 'lz4'
+  'openssl' 'zstd' 'cubeb' 'enet' 'discord-rpc' 'cpp-httplib' 'mbedtls' 'ffmpeg'
+  'wireless_tools'
+  'quazip-qt6'
+  # 'dynarmic' # eden use forked dynarmic with some patches
+)
+makedepends=('llvm' 'git' 'glslang' 'cmake' 'ninja' 'perl' 'clang' 'patch'
+  'qt6-tools' 'qt6-multimedia' 'libxkbcommon-x11' 'libzip' 'libfdk-aac' 'libinih'
+  'vulkan-memory-allocator' 'vulkan-utility-libraries' 'vulkan-headers' 'spirv-headers'
+  'boost' 'nlohmann-json' 'robin-map' 'cpp-jwt' 'gamemode' 'python' 'renderdoc'
+  rapidjson zycore-c
+  unordered_dense
+
+  # 'xbyak' #
+  zydis
+
+  # for documentation
+  # 'doxygen' 'python-jinja' 'python-jsonschema' 'graphviz'
+
+  # for testing
+  # 'catch2'
+)
+optdepends=('qt6-wayland: for Wayland support')
+source=(
+  eden::git+${url}.git
+  "nx_tzdb-${_tzdb_ver}.tar.gz::https://git.crueter.xyz/misc/tzdb_to_nx/releases/download/${_tzdb_ver}/${_tzdb_ver}.tar.gz"
+)
+b2sums=('SKIP'
+  '6619b7ad2200be8efb495773d017a07985adb7b05ba97285427aa86103ae9a8c9befc698709539a0292c413c2c8082c39fd699e181140e6879844084e5c19382')
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  git describe --long --tags --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/pre.alpha.//g' | sed 's/^v//'
+}
+
+build() {
+  export CC=clang
+  export CXX=clang++
+
+  local cmake_args=(
+    -GNinja
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+    -DTITLE_BAR_FORMAT_IDLE="$_pkgname $pkgver"
+    -DTITLE_BAR_FORMAT_RUNNING="$_pkgname $pkgver | {3}"
+    -DCMAKE_INSTALL_PREFIX=/usr
+    -DCMAKE_BUILD_TYPE=Release
+    -DYUZU_ENABLE_COMPATIBILITY_REPORTING=OFF
+    -DYUZU_USE_QT_WEB_ENGINE=ON
+    -DUSE_DISCORD_PRESENCE=ON
+    -DENABLE_QT_TRANSLATION=ON
+    -DYUZU_USE_BUNDLED_FFMPEG=OFF
+    -DYUZU_USE_BUNDLED_QT=OFF
+    -DYUZU_USE_EXTERNAL_SDL2=OFF
+    -DYUZU_USE_FASTER_LD=OFF
+    -DYUZU_USE_QT_MULTIMEDIA=ON
+    -DYUZU_DOWNLOAD_TIME_ZONE_DATA=ON
+    -DYUZU_TZDB_PATH=${srcdir}/nx-tzdb-${_tzdb_ver}
+    -DYUZU_TESTS=OFF
+    -DSIRIT_USE_SYSTEM_SPIRV_HEADERS=ON
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    -DDYNARMIC_TESTS=OFF
+    -DYUZU_USE_CPM=OFF
+    -DJSON_BUNDLED_PACKAGE=OFF
+    -DENABLE_WIFI_SCAN=ON
+  )
+  install -d build
+  cmake -S ${_pkgname} -B build "${cmake_args[@]}"
+  ninja -C build
+
+}
+
+package() {
+  install -Dm644 $srcdir/${_pkgname}/dist/72-${_cmd}-input.rules -t ${pkgdir}/usr/lib/udev/rules.d/
+  DESTDIR="$pkgdir/" ninja -C $srcdir/build install
+}

--- a/archlinuxcn/eden-git/lilac.yaml
+++ b/archlinuxcn/eden-git/lilac.yaml
@@ -1,0 +1,25 @@
+maintainers:
+  - github: sukanka
+    email: su975853527@gmail.com
+
+build_prefix: extra-x86_64
+
+pre_build: vcs_update
+post_build: git_pkgbuild_commit
+
+repo_depends:
+  - discord-rpc-git
+  - cubeb-git
+  - cpp-httplib
+  - cpp-jwt
+  - vulkan-memory-allocator-git
+  - unordered_dense-git
+
+update_on:
+  - source: alpm
+    alpm: fmt
+    repo: extra
+  - source: alpm
+    alpm: openssl
+  - alias: boost
+  - source: vcs

--- a/archlinuxcn/unordered_dense-git/PKGBUILD
+++ b/archlinuxcn/unordered_dense-git/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Sukanka <su975853527 [at] gmail [dot] com>
+# Contributor: Jonathan Hilger <joni dot hilger at yahoo dot de>
+pkgname=unordered_dense-git
+pkgver=r271.3234af2
+pkgrel=1
+pkgdesc="A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
+arch=('any')
+url="https://github.com/martinus/unordered_dense"
+license=('MIT')
+depends=('gcc-libs' 'glibc')
+makedepends=('git' 'cmake')
+provides=('unordered_dense')
+source=("${pkgname}::git+https://github.com/martinus/unordered_dense.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${pkgname}"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+} # pkgver
+
+build() {
+    cd "${srcdir}/${pkgname}"
+    cmake -B build \
+        -DCMAKE_INSTALL_PREFIX=/usr
+    cmake --build build
+} # build
+
+package() {
+    cd "${srcdir}/${pkgname}/build"
+    DESTDIR="${pkgdir}" make install
+    install -Dm644 "${srcdir}/${pkgname}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+} # package

--- a/archlinuxcn/unordered_dense-git/lilac.yaml
+++ b/archlinuxcn/unordered_dense-git/lilac.yaml
@@ -1,0 +1,9 @@
+maintainers:
+  - github: sukanka
+    email: su975853527@gmail.com
+
+build_prefix: extra-x86_64
+pre_build: vcs_update
+post_build: git_pkgbuild_commit
+update_on:
+  - source: vcs


### PR DESCRIPTION
eden 是 yuzu的一个分支，但是做了一些改进，并将一些组件进行了更新，使得我们可以尽量使用系统的组件进行构建。

由于 eden 和 yuzu 在构建产物上只有启动命令有差别，而其他文件一致，因此与yuzu 冲突。
目前在 NV显卡上跑游戏不会 crash 了，不过仅限通过X11启动应用的情况。