### PR TITLE
maa-assistant-arknights: fix build( again)

### DIFF
--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -108,6 +108,8 @@ build() {
         local _cmake_flags+=(
             -DWITH_CUDA=ON
             -DCUDA_DIRECTORY=/opt/cuda
+            -DCUDAToolkit_ROOT=/opt/cuda
+            -DCMAKE_CUDA_COMPILER=/opt/cuda/bin/nvcc
             -DCUDA_ARCH_NAME=Auto
         )
         


### PR DESCRIPTION
Attempts to fix build again. Non cuda version tested, built successfully. Cuda version hit oom, so let build machines try that out.