### PR TITLE
maa-assistant-arknights: fix build by removing failed sed

### DIFF
--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -135,6 +135,8 @@ package_maa-assistant-arknights() {
 
 package_maa-assistant-arknights-cuda() {
     pkgdesc="${_pkgdesc} (with CUDA)"
+    provides=(maa-assistant-arknights)
+    conflicts=(maa-assistant-arknights)
     depends+=(cuda)
 
     cmake --install "$srcdir"/build-cuda --prefix "$pkgdir"/usr


### PR DESCRIPTION
This pr also adds [provides & conflicts for cuda version](https://github.com/archlinuxcn/repo/commit/0c070cabb0ee287b6a9b2332cf13ad6978f84309)