### PR TITLE
 devtools-archlinuxcn: update to 1.5.0

### DIFF
--- a/archlinuxcn/devtools-archlinuxcn/PKGBUILD
+++ b/archlinuxcn/devtools-archlinuxcn/PKGBUILD
@@ -5,8 +5,8 @@
 _pkgname=devtools
 pkgname=devtools-archlinuxcn
 epoch=1
-pkgver=1.3.0
-pkgrel=2
+pkgver=1.5.0
+pkgrel=1
 _tag=$pkgver-archlinuxcn1
 _upstream_pkgrel=1
 pkgdesc='Tools for Arch Linux package maintainers, archlinuxcn fork'
@@ -30,10 +30,11 @@ depends=(
   jq
   openssh
   parallel
+  reuse
   rsync
   sed
   util-linux
-
+  sudo
   breezy
   git
   mercurial
@@ -41,7 +42,6 @@ depends=(
 )
 makedepends=(
   asciidoctor
-  shellcheck
 )
 checkdepends=(
   bats
@@ -55,7 +55,9 @@ provides=("devtools=$pkgver-$pkgrel")
 conflicts=("devtools")
 source=("$pkgname::git+https://github.com/archlinuxcn/devtools.git#tag=$_tag"
         "ssh_allowed_signers")
-b2sums=('5480664e50ddaeb8806949be00fd5c657914cd01a5b630707f4a52b4f61ece264fb00381176d14711fcee0cb305c1ecc9b4ebb26b1c5902fd2c95dc34b9ee911'
+sha256sums=('ad28c6604539a2f52779a379e234f2aa4e8df109c0e9c99d0806c2c2fdf78872'
+            'b83e8c654e3af93d6bb173db51d59f2f422fc5c777efe4253b26cfbaba6f0943')
+b2sums=('1372f345809edb9a16ffa8f7e2ec1594fbb86121a506e82908b17a4253787f287c607ef5df4703c94b9296557c0b665cc3bbcd7248cd40709ff9c891440d8a49'
         '6c9fab6619bcc3ab0d1bf0944a6dc53296caa1a2dccb0cf833957c5820f3f47bae44d26ed85edf294b4efffb18b59773cfb7f89ea961c582556b4a28ee1f9d0c')
 
 # XXX: move to verify() when devtools supports it


### PR DESCRIPTION
* Sync PKGBUILD with upstream https://gitlab.archlinux.org/archlinux/packaging/packages/devtools/-/commits/main

---

Somehow I forgot about 1.4.x. Let's catch up with 1.5.0, which looks nice with proper support for pacman 7.1

* One conflict between https://github.com/archlinuxcn/devtools/commit/803c6d3a34b61fbc31fe4908101a1e34b862a9ae and https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/335. Looks trivial to fix.
* I only test building this package. More testing is necessary.
* [Upstream commits](https://github.com/archlinux/devtools/compare/v1.3.0...v1.5.0) look moderate - mostly support for pacman 7.1 and updates of build flags if pkgctl-related changes are excluded.