### PR TITLE
hmcl: use the prereleases tag as a workaround

### DIFF
--- a/archlinuxcn/hmcl/lilac.yaml
+++ b/archlinuxcn/hmcl/lilac.yaml
@@ -12,5 +12,7 @@ post_build_script: |
 update_on:
   - source: github
     github: HMCL-dev/HMCL
-    use_latest_release: true
+    use_max_release: true
+    include_prereleases: true
+    include_regex: 'v(\d+\.\d+\.\d+)'
     prefix: v


### PR DESCRIPTION
hmcl的上游最近似乎采用奇怪的方式发布稳定版，大于v3.9.2的稳定版（比如v3.10.2）都被作为prereleaes发布了，这个pr提出一种workaround去缓解这个问题
稳定版本版本号参考来源：https://docs.hmcl.net/changelog/stable.html#nowchange