### PR TITLE
add package: process-compose-bin

### DIFF
--- a/alarmcn/process-compose-bin/PKGBUILD
+++ b/alarmcn/process-compose-bin/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: SkyNetX007 <skynetx007@proton.me>
+pkgname=process-compose-bin
+_pkgname=${pkgname%-bin}
+pkgver=1.90.0
+pkgrel=1
+pkgdesc="Process Compose is a simple and flexible scheduler and orchestrator to manage non-containerized applications."
+arch=('x86_64' 'aarch64')
+url="https://github.com/F1bonacc1/process-compose"
+license=('Apache-2.0')
+provides=('process-compose')
+conflicts=('process-compose')
+options=('!debug')
+source_x86_64=("${pkgname}-${pkgver}-amd64.tar.gz::${url}/releases/download/v${pkgver}/process-compose_linux_amd64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-arm64.tar.gz::${url}/releases/download/v${pkgver}/process-compose_linux_arm64.tar.gz")
+
+sha256sums_x86_64=('bdc90c6d4ad796ab0af0e0be2bea1a9d38d51b8c94912c4039136aa2046a6e1e')
+sha256sums_aarch64=('593e89c081f888c0e1d8b4d57c9d0afedfa5c29b63d2ce365d6cba82dbaa4db4')
+
+package() {
+        cd "${srcdir}"
+        install -Dm755 process-compose "${pkgdir}/usr/bin/${_pkgname}"
+        install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+        install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+        mkdir -p "${pkgdir}/usr/share/bash-completion/completions"
+        mkdir -p "${pkgdir}/usr/share/zsh/site-functions"
+        mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d"
+
+        ./process-compose completion bash > "${pkgdir}/usr/share/bash-completion/completions/${_pkgname}"
+        ./process-compose completion zsh > "${pkgdir}/usr/share/zsh/site-functions/_${_pkgname}"
+        ./process-compose completion fish > "${pkgdir}/usr/share/fish/vendor_completions.d/${_pkgname}.fish"
+}

--- a/alarmcn/process-compose-bin/lilac.yaml
+++ b/alarmcn/process-compose-bin/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: SkyNetX007
+    email: SkyNetX007 <skynetx007@proton.me>
+
+pre_build_script: |
+    update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+    git_add_repo_pkgbuild()
+    git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: F1bonacc1/process-compose
+    prefix: v
+    use_latest_release: true

--- a/archlinuxcn/process-compose-bin/PKGBUILD
+++ b/archlinuxcn/process-compose-bin/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: SkyNetX007 <skynetx007@proton.me>
+pkgname=process-compose-bin
+_pkgname=${pkgname%-bin}
+pkgver=1.90.0
+pkgrel=1
+pkgdesc="Process Compose is a simple and flexible scheduler and orchestrator to manage non-containerized applications."
+arch=('x86_64' 'aarch64')
+url="https://github.com/F1bonacc1/process-compose"
+license=('Apache-2.0')
+provides=('process-compose')
+conflicts=('process-compose')
+options=('!debug')
+source_x86_64=("${pkgname}-${pkgver}-amd64.tar.gz::${url}/releases/download/v${pkgver}/process-compose_linux_amd64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-arm64.tar.gz::${url}/releases/download/v${pkgver}/process-compose_linux_arm64.tar.gz")
+
+sha256sums_x86_64=('bdc90c6d4ad796ab0af0e0be2bea1a9d38d51b8c94912c4039136aa2046a6e1e')
+sha256sums_aarch64=('593e89c081f888c0e1d8b4d57c9d0afedfa5c29b63d2ce365d6cba82dbaa4db4')
+
+package() {
+        cd "${srcdir}"
+        install -Dm755 process-compose "${pkgdir}/usr/bin/${_pkgname}"
+        install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+        install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+        mkdir -p "${pkgdir}/usr/share/bash-completion/completions"
+        mkdir -p "${pkgdir}/usr/share/zsh/site-functions"
+        mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d"
+
+        ./process-compose completion bash > "${pkgdir}/usr/share/bash-completion/completions/${_pkgname}"
+        ./process-compose completion zsh > "${pkgdir}/usr/share/zsh/site-functions/_${_pkgname}"
+        ./process-compose completion fish > "${pkgdir}/usr/share/fish/vendor_completions.d/${_pkgname}.fish"
+}

--- a/archlinuxcn/process-compose-bin/lilac.yaml
+++ b/archlinuxcn/process-compose-bin/lilac.yaml
@@ -1,0 +1,16 @@
+maintainers:
+  - github: SkyNetX007
+    email: SkyNetX007 <skynetx007@proton.me>
+
+pre_build_script: |
+    update_pkgver_and_pkgrel(_G.newver)
+
+post_build_script: |
+    git_add_repo_pkgbuild()
+    git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: F1bonacc1/process-compose
+    prefix: v
+    use_latest_release: true


### PR DESCRIPTION
## Package Introduction
process-compose-bin is a lightweight, Go-based process manager (similar to PM2, but with a TUI interface).

## Packaging Notes

Binary Source: Directly sourced from official GitHub Releases, avoiding the heavy resource consumption of source compilation on low-end machines (e.g., low-RAM VPS).

Relationship with AUR: This is the binary (-bin) version of the process-compose package on AUR, facilitating quick installation for community users. By the way, [process-compose](https://aur.archlinux.org/packages/process-compose) on AUR has been out of date for a long time. 

Optimizations: Added native shell completion support for Bash, Zsh, and Fish. Fixed the missing LICENSE and README.md files in the AUR package, ensuring strict adherence to Arch Linux packaging standards.

## 软件包简介
process-compose-bin 是一个基于 Go 语言的轻量级进程管理工具（类似于 PM2，但提供 TUI 界面）。

## 打包说明

二进制来源：直接取自 GitHub 官方 Release 的预编译二进制，省去了低配置机器（如小内存 VPS）上源码编译的开销。

与 AUR 的关系：本包是 AUR 中 process-compose 的二进制版本（-bin），方便在低配设备上快速安装。[process-compose](https://aur.archlinux.org/packages/process-compose) AUR版本已经长期未更新，因此新增二进制包。

主要优化：修正了 AUR 版本缺少 LICENSE 和 README.md 的问题，提供 Shell 补全功能。