### PR TITLE
ci: pin dependency version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: pip install jsonschema pyyaml
-    - name: Run test
-      run: ./pre-commit --all
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: pip install jsonschema==4.26.0 pyyaml==6.0.3
+      - name: Run test
+        run: ./pre-commit --all


### PR DESCRIPTION
1. pin all action to a fixed version
2. upgrade Python to 3.14
3. pin all Python dependency version

Prevent dependency poison