### PR TITLE
maa-assistant-arknights: fix building cuda using gcc13 for now

### DIFF
--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -95,6 +95,7 @@ build() {
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DCMAKE_INSTALL_PREFIX="$pkgdir"/usr
         -DMAA_VERSION="v$_pkgver"
+        -DMAA_HASH_VERSION="v$_pkgver" # taken from ci workflow
         -Dfastdeploy_SOURCE_DIR="$srcdir"/FastDeploy-"$_fastdeploy_ref"
         -Dfastdeploy_BINARY_DIR="$srcdir"/build-FastDeploy
     )

--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -7,7 +7,7 @@
 
 _pkgname=maa-assistant-arknights
 pkgname=(maa-assistant-arknights)
-_pkgver=6.9.0
+_pkgver=6.9.2
 pkgver=${_pkgver//-/}
 pkgrel=1
 _pkgdesc="An Arknights assistant"
@@ -21,7 +21,7 @@ source=("git+$url.git#tag=v${_pkgver}"
 "git+https://github.com/MaaXYZ/MaaUtils.git"
 "FastDeploy-${_fastdeploy_ref}.tar.gz::https://github.com/MaaXYZ/FastDeploy/archive/$_fastdeploy_ref.tar.gz")
 install="${_pkgname}.install"
-md5sums=('551f08aca7ce473e2e36353f884d5425'
+md5sums=('2fc85c4939bd709f62315dabf27d550a'
          'SKIP'
          '4555f8dce0cec02022356d50c8f2275c')
 

--- a/archlinuxcn/maa-assistant-arknights/PKGBUILD
+++ b/archlinuxcn/maa-assistant-arknights/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Horror Proton <https://github.com/horror-proton>
 # Maintainer: Cryolitia <cryolitia at gmail dot com>
+# Maintainer: CommDServ <commdserv at outlook dot com>
 
 # shellcheck disable=SC2034 disable=SC2164
 
@@ -27,7 +28,7 @@ md5sums=('2fc85c4939bd709f62315dabf27d550a'
 
 if ((WITH_CUDA)); then
     pkgname+=(maa-assistant-arknights-cuda)
-    makedepends+=(cuda)
+    makedepends+=(cuda gcc13)
 fi
 
 prepare() {
@@ -113,8 +114,8 @@ build() {
             -DCUDA_ARCH_NAME=Auto
         )
         
-        cmake -B build-cuda -S "MaaAssistantArknights" "${_cmake_flags[@]}"
-        cmake --build build-cuda
+        NVCC_CCBIN=g++-13 cmake -B build-cuda -S "MaaAssistantArknights" "${_cmake_flags[@]}"
+        NVCC_CCBIN=g++-13 cmake --build build-cuda
     fi
 }
 


### PR DESCRIPTION
最近官方仓库的gcc升级到了16，导致maa的cuda部分编译报错。我尝试指定-DCMAKE_CUDA_STANDARD=17，但是没有作用。

所以暂时使用archcn仓库里版本最高的gcc13编译cuda部分，使用NVCC_CCBIN=g++-13指定。

其它改动：
- 使用maa ci workflow里的方式指定版本号
- 顺便bump到6.9.2
- 添加我的联系信息