### PR TITLE
xone-dkms-git: move modprobe config to /usr/lib/modprobe.d

### DIFF
--- a/archlinuxcn/xone-dkms-git/PKGBUILD
+++ b/archlinuxcn/xone-dkms-git/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=xone
 pkgname=xone-dkms-git
 pkgver=0.5.7.r9.gf2aa9fe
-pkgrel=1
+pkgrel=2
 pkgdesc='Modern Linux driver for Xbox One and Xbox Series X|S controllers'
 arch=('x86_64')
 url='https://github.com/dlundqvist/xone'

--- a/archlinuxcn/xone-dkms-git/PKGBUILD
+++ b/archlinuxcn/xone-dkms-git/PKGBUILD
@@ -34,6 +34,6 @@ package() {
   cp -r ${srcdir}/$_pkgname/* "${pkgdir}/usr/src/${_pkgname}-${pkgver}"
 
   echo "* Blacklisting xpad module..."
-  install -D -m 644 install/modprobe.conf "${pkgdir}/etc/modprobe.d/xone-blacklist.conf"
+  install -D -m 644 install/modprobe.conf "${pkgdir}/usr/lib/modprobe.d/xone-blacklist.conf"
 }
 


### PR DESCRIPTION
Packaged modprobe.d config belongs to /usr instead of /etc.