### PR TITLE
collectd: add redis support

### DIFF
--- a/archlinuxcn/collectd/PKGBUILD
+++ b/archlinuxcn/collectd/PKGBUILD
@@ -27,6 +27,7 @@ optdepends=('curl: apache, ascent, curl, nginx, and write_http plugins'
             'postgresql-libs: postgresql plugin'
             'python: python plugin'
             'rrdtool: rrdtool and rrdcached plugins'
+            'hiredis': 'redis plugin'
             'lm_sensors: lm_sensors and sensors plugins'
             'libvirt: libvirt plugin'
             'libxml2: ascent and libvirt plugins'
@@ -73,6 +74,7 @@ build() {
 		--sysconfdir=/etc \
 		--localstatedir=/var \
 		--sbindir=/usr/bin \
+		--enable-redis \
 		--disable-werror \
 		--with-perl-bindings='INSTALLDIRS=vendor' \
 

--- a/archlinuxcn/collectd/PKGBUILD
+++ b/archlinuxcn/collectd/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=collectd
 pkgver=5.12.0
-pkgrel=21
+pkgrel=22
 pkgdesc='Daemon which collects system performance statistics periodically'
 url='https://collectd.org/'
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
Add support of Collectd's builtin [redis plugin](https://github.com/collectd/collectd/wiki/Plugin-Redis).

The `redis` and `write_redis` plugins are not enabled in default config so it's safe for systems without `hiredis` installed to upgrade.

> ps, I split upgrading `pkgrel` to different commit to make it easier for potential patching or cherry-picking