### PR TITLE
addpkg: lwe

### DIFF
--- a/archlinuxcn/lwe/PKGBUILD
+++ b/archlinuxcn/lwe/PKGBUILD
@@ -1,0 +1,32 @@
+pkgname=lwe
+pkgver=0.9.9
+pkgrel=1
+pkgdesc="Linux dynamic wallpaper shell for Wallpaper Engine content"
+arch=('x86_64')
+url="https://github.com/YangYuS8/lwe"
+license=('MIT')
+depends=('cairo' 'desktop-file-utils' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libsoup' 'pango' 'webkit2gtk-4.1')
+provides=('lwe')
+conflicts=('lwe-git')
+source=("lwe_0.9.9_amd64.deb::https://github.com/YangYuS8/lwe/releases/download/v0.9.9/lwe_0.9.9_amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+	cd "${srcdir}"
+	bsdtar -xf "lwe_${pkgver}_amd64.deb"
+
+	local data_archive=""
+	for candidate in data.tar.zst data.tar.xz data.tar.gz; do
+		if [ -f "${candidate}" ]; then
+			data_archive="${candidate}"
+			break
+		fi
+	done
+
+	if [ -z "${data_archive}" ]; then
+		echo "No Debian payload archive found in deb package"
+		return 1
+	fi
+
+	bsdtar -xf "${data_archive}" -C "${pkgdir}"
+}

--- a/archlinuxcn/lwe/lilac.yaml
+++ b/archlinuxcn/lwe/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: YangYuS8
+
+build_prefix: extra-x86_64
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    github: YangYuS8/lwe
+    use_latest_release: true
+    prefix: v


### PR DESCRIPTION
Add LWE stable package metadata.

Initial version: 0.9.9.

This PR payload was generated from YangYuS8/lwe@38e20ca0730ef630049ac66bda98242e7f8e26cc.