### PR TITLE
jellyfin-desktop: rebuild on mpvqt update

### DIFF
--- a/archlinuxcn/jellyfin-desktop/lilac.yaml
+++ b/archlinuxcn/jellyfin-desktop/lilac.yaml
@@ -11,3 +11,6 @@ post_build: aur_post_build
 update_on:
   - source: aur
     aur: jellyfin-desktop
+  - source: alpm
+    alpm: mpvqt
+    strip_release: true


### PR DESCRIPTION
Jellyfin desktop seems to depend on libMpvQt.so.x with specific version constraint and needs to be rebuilt when said package updates

Context:

jellyfin-desktop: error while loading shared libraries: libMpvQt.so.2: cannot open shared object file: No such file or directory