### PR TITLE
addpkg: cine

### DIFF
--- a/archlinuxcn/cine/PKGBUILD
+++ b/archlinuxcn/cine/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Mark Wagie <mark dot wagie at proton dot me>
+pkgname=cine
+pkgver=1.6.0
+pkgrel=1
+pkgdesc="Video Player for Linux"
+arch=('any')
+url="https://github.com/diegopvlk/Cine"
+license=('GPL-3.0-or-later')
+depends=(
+  'dconf'
+  'glib2'
+  'gtk4'
+  'hicolor-icon-theme'
+  'libadwaita'
+  'pango'
+  'python3'
+  'python-gobject'
+  'python-mpv'
+)
+makedepends=(
+  'blueprint-compiler'
+  'meson'
+)
+source=("Cine-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('70717966a491506d5bf6f0f7d93e99d96e24b9c66b8c0820a73cccdd5ccd16b5')
+
+build() {
+  arch-meson "Cine-$pkgver" build
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --no-rebuild --print-errorlogs
+}
+
+package() {
+  meson install -C build --no-rebuild --destdir "$pkgdir"
+}

--- a/archlinuxcn/cine/lilac.yaml
+++ b/archlinuxcn/cine/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: dongfengweixiao
+    email: Dee.H.Y <dongfengweixiao@hotmail.com>
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    github: diegopvlk/Cine
+    use_latest_release: true
+    prefix: v


### PR DESCRIPTION
#4762 

```build.log
Cine-1.6.0 has no wrap files
+ exec meson setup --prefix /usr --libexecdir lib --sbindir bin --buildtype plain --auto-features enabled --wrap-mode nodownload -D b_pie=true -D python.bytecompile=1 Cine-1.6.0 build
The Meson build system
Version: 1.11.1
Source dir: /build/cine/src/Cine-1.6.0
Build dir: /build/cine/src/build
Build type: native build
Project name: cine
Project version: 1.6.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program msgfmt found: YES (/usr/bin/msgfmt)
Program desktop-file-validate found: YES (/usr/bin/desktop-file-validate)
Program appstreamcli found: YES (/usr/bin/appstreamcli)
Program glib-compile-schemas found: YES (/usr/bin/glib-compile-schemas)
Configuring io.github.diegopvlk.Cine.service using configuration
Program blueprint-compiler found: YES (/usr/bin/blueprint-compiler)
Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
Build-time dependency gio-2.0 found: YES 2.88.1
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources)
Program python3 found: YES (/usr/bin/python3)
Configuring cine using configuration
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Dependency gio-2.0 for build machine found: YES 2.88.1 (cached)
Program /usr/bin/glib-compile-schemas found: YES (/usr/bin/glib-compile-schemas)
Program gtk4-update-icon-cache found: YES (/usr/bin/gtk4-update-icon-cache)
Program update-desktop-database found: YES (/usr/bin/update-desktop-database)
Build targets in project: 27

cine 1.6.0

  User defined options
    auto_features     : enabled
    b_pie             : true
    buildtype         : plain
    libexecdir        : lib
    prefix            : /usr
    python.bytecompile: 1
    sbindir           : bin
    wrap_mode         : nodownload

Found ninja-1.13.2 at /usr/bin/ninja

Generating targets:   0%|          | 0/27 eta ?
                                               

Writing build.ninja:   0%|          | 0/55 eta ?
                                                
ninja: Entering directory `/build/cine/src/build'
[1/24] Building translation po/ar/LC_MESSAGES/cine-ar.mo
[2/24] Building translation po/cs/LC_MESSAGES/cine-cs.mo
[3/24] Building translation po/de/LC_MESSAGES/cine-de.mo
[4/24] Building translation po/en_GB/LC_MESSAGES/cine-en_GB.mo
[5/24] Building translation po/es/LC_MESSAGES/cine-es.mo
[6/24] Building translation po/et/LC_MESSAGES/cine-et.mo
[7/24] Building translation po/fa/LC_MESSAGES/cine-fa.mo
[8/24] Building translation po/fi/LC_MESSAGES/cine-fi.mo
[9/24] Building translation po/fr/LC_MESSAGES/cine-fr.mo
[10/24] Building translation po/it/LC_MESSAGES/cine-it.mo
[11/24] Building translation po/nl/LC_MESSAGES/cine-nl.mo
[12/24] Building translation po/oc/LC_MESSAGES/cine-oc.mo
[13/24] Building translation po/pt/LC_MESSAGES/cine-pt.mo
[14/24] Building translation po/pt_BR/LC_MESSAGES/cine-pt_BR.mo
[15/24] Building translation po/ru/LC_MESSAGES/cine-ru.mo
[16/24] Building translation po/si/LC_MESSAGES/cine-si.mo
[17/24] Building translation po/ta/LC_MESSAGES/cine-ta.mo
[18/24] Building translation po/tr/LC_MESSAGES/cine-tr.mo
[19/24] Building translation po/ur/LC_MESSAGES/cine-ur.mo
[20/24] Building translation po/zh_CN/LC_MESSAGES/cine-zh_CN.mo
[21/24] Merging translations for data/io.github.diegopvlk.Cine.metainfo.xml
[22/24] Merging translations for data/io.github.diegopvlk.Cine.desktop
[23/24] Generating src/blueprints with a custom command
[24/24] Generating src/cine_gresource with a custom command
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /build/cine/src/build
```

``` check.log
1/3 cine:Validate desktop file   OK              0.01s
2/3 cine:Validate schema file    OK              0.01s
3/3 cine:Validate appstream file OK              0.02s

Ok:                3   
Fail:              0   

Full log written to /build/cine/src/build/meson-logs/testlog.txt
```
``` package.log
Installing data/io.github.diegopvlk.Cine.desktop to /build/cine/pkg/cine/usr/share/applications
Installing data/io.github.diegopvlk.Cine.metainfo.xml to /build/cine/pkg/cine/usr/share/metainfo
Installing src/cine.gresource to /build/cine/pkg/cine/usr/share/cine
Installing po/ar/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/ar/LC_MESSAGES
Installing po/cs/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/cs/LC_MESSAGES
Installing po/de/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/de/LC_MESSAGES
Installing po/en_GB/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/en_GB/LC_MESSAGES
Installing po/es/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/es/LC_MESSAGES
Installing po/et/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/et/LC_MESSAGES
Installing po/fa/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/fa/LC_MESSAGES
Installing po/fi/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/fi/LC_MESSAGES
Installing po/fr/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/fr/LC_MESSAGES
Installing po/it/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/it/LC_MESSAGES
Installing po/nl/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/nl/LC_MESSAGES
Installing po/oc/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/oc/LC_MESSAGES
Installing po/pt/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/pt/LC_MESSAGES
Installing po/pt_BR/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/pt_BR/LC_MESSAGES
Installing po/ru/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/ru/LC_MESSAGES
Installing po/si/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/si/LC_MESSAGES
Installing po/ta/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/ta/LC_MESSAGES
Installing po/tr/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/tr/LC_MESSAGES
Installing po/ur/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/ur/LC_MESSAGES
Installing po/zh_CN/LC_MESSAGES/cine.mo to /build/cine/pkg/cine/usr/share/locale/zh_CN/LC_MESSAGES
Installing /build/cine/src/Cine-1.6.0/data/io.github.diegopvlk.Cine.gschema.xml to /build/cine/pkg/cine/usr/share/glib-2.0/schemas
Installing /build/cine/src/build/data/io.github.diegopvlk.Cine.service to /build/cine/pkg/cine/usr/share/dbus-1/services
Installing /build/cine/src/Cine-1.6.0/data/icons/hicolor/scalable/apps/io.github.diegopvlk.Cine.svg to /build/cine/pkg/cine/usr/share/icons/hicolor/scalable/apps
Installing /build/cine/src/Cine-1.6.0/data/icons/hicolor/symbolic/apps/io.github.diegopvlk.Cine-symbolic.svg to /build/cine/pkg/cine/usr/share/icons/hicolor/symbolic/apps
Installing /build/cine/src/build/src/cine to /build/cine/pkg/cine/usr/bin
Installing /build/cine/src/Cine-1.6.0/src/__init__.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/main.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/mpris.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/options.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/playlist.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/preferences.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/save_session.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/shortcuts.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/utils.py to /build/cine/pkg/cine/usr/share/cine/cine
Installing /build/cine/src/Cine-1.6.0/src/window.py to /build/cine/pkg/cine/usr/share/cine/cine
Skipping custom install script because DESTDIR is set '/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas'
Skipping custom install script because DESTDIR is set '/usr/bin/gtk4-update-icon-cache -q -t -f /usr/share/icons/hicolor'
Skipping custom install script because DESTDIR is set '/usr/bin/update-desktop-database -q /usr/share/applications'
```