### PR TITLE
addpkg: m78-bin

### DIFF
--- a/archlinuxcn/m78-bin/PKGBUILD
+++ b/archlinuxcn/m78-bin/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: zxzxzx258 <25838226+zxzxzx258@users.noreply.github.com>
+pkgname=m78-bin
+pkgver=3.0.0
+_buildver=2026041016
+pkgrel=1
+pkgdesc='M78 官方二进制客户端'
+arch=('x86_64')
+url='https://appdownload.m78node.com/download.php'
+license=('custom')
+makedepends=('patchelf')
+depends=(
+  'gtk3'
+  'hicolor-icon-theme'
+  'java-runtime-headless'
+  'libkeybinder3'
+  'libayatana-appindicator'
+  'libcap'
+  'libx11'
+  'libxcomposite'
+  'libxcursor'
+  'libxdamage'
+  'libxfixes'
+  'libxi'
+  'libxinerama'
+  'libxrandr'
+  'libxrender'
+  'sqlite'
+  'xdg-utils'
+)
+provides=('mqiba')
+conflicts=('mqiba')
+replaces=('mqiba')
+install='m78-bin.install'
+source=(
+  'm78-3.0.0-linux-amd64.deb::https://appdownload.m78node.com/download.php?f=linux_deb'
+  'm78-3.0.0-linux-amd64.rpm::https://appdownload.m78node.com/download.php?f=linux_rpm'
+  'mqiba-wrapper'
+)
+sha256sums=(
+  '2df141685a8738a0f7df6824982d68dd11649b44b990b7efe270f7ffd4ea208c'
+  '27c368aa7a6fa0d40a543e663b505ce2b0906e312ee9debb989a22aa72ad387e'
+  'b7a138bac3d85e5e871dbe424d3d138f3cf4ba055260d674ebd23864daf30501'
+)
+
+prepare() {
+  rm -rf deb-archive deb-root rpm-root
+  mkdir -p deb-archive deb-root rpm-root
+
+  bsdtar -xf "${srcdir}/m78-3.0.0-linux-amd64.deb" -C "${srcdir}/deb-archive"
+  bsdtar -xf "${srcdir}/deb-archive/data.tar.zst" -C "${srcdir}/deb-root"
+  bsdtar -xf "${srcdir}/m78-3.0.0-linux-amd64.rpm" -C "${srcdir}/rpm-root"
+}
+
+package() {
+  install -dm755 "${pkgdir}/usr/bin"
+  install -dm755 "${pkgdir}/usr/lib"
+  install -dm755 "${pkgdir}/usr/share"
+
+  cp -dr --no-preserve=ownership "${srcdir}/deb-root/usr/share/mqiba" "${pkgdir}/usr/lib/"
+  cp -dr --no-preserve=ownership "${srcdir}/deb-root/usr/share/applications" "${pkgdir}/usr/share/"
+  sed -i 's/^Keywords=.*/Keywords=M78;Network;Utility;/' "${pkgdir}/usr/share/applications/mqiba.desktop"
+
+  if [[ -d "${srcdir}/deb-root/usr/share/icons" ]]; then
+    cp -dr --no-preserve=ownership "${srcdir}/deb-root/usr/share/icons" "${pkgdir}/usr/share/"
+  fi
+
+  if [[ -f "${srcdir}/rpm-root/usr/share/pixmaps/mqiba.png" ]]; then
+    install -Dm644 "${srcdir}/rpm-root/usr/share/pixmaps/mqiba.png" "${pkgdir}/usr/share/pixmaps/mqiba.png"
+  fi
+
+  install -Dm755 "${srcdir}/mqiba-wrapper" "${pkgdir}/usr/bin/mqiba"
+
+  find "${pkgdir}/usr/lib/mqiba/lib" -type f -name '*.so' -exec patchelf --set-rpath '$ORIGIN' {} +
+  chmod 755 "${pkgdir}/usr/lib/mqiba/mqiba" "${pkgdir}/usr/lib/mqiba/mqibaCore"
+  find "${pkgdir}/usr/lib/mqiba" -type d -exec chmod 755 {} +
+  find "${pkgdir}/usr/lib/mqiba" -type f ! -path '*/mqiba' ! -path '*/mqibaCore' -exec chmod 644 {} +
+}

--- a/archlinuxcn/m78-bin/PKGBUILD
+++ b/archlinuxcn/m78-bin/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: zxzxzx258 <25838226+zxzxzx258@users.noreply.github.com>
+# Maintainer: zxzxzx258 <zxzxzx258@gmail.com>
 pkgname=m78-bin
 pkgver=3.0.0
 _buildver=2026041016

--- a/archlinuxcn/m78-bin/PKGBUILD
+++ b/archlinuxcn/m78-bin/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: zxzxzx258 <zxzxzx258@gmail.com>
 pkgname=m78-bin
-pkgver=3.0.0
-_buildver=2026041016
+pkgver=3.1.5
+_buildver=2026070610
 pkgrel=1
-pkgdesc='M78 官方二进制客户端'
+pkgdesc='M78 代理客户端官方二进制重打包'
 arch=('x86_64')
 url='https://appdownload.m78node.com/download.php'
 license=('custom')
@@ -32,23 +32,20 @@ conflicts=('mqiba')
 replaces=('mqiba')
 install='m78-bin.install'
 source=(
-  'm78-3.0.0-linux-amd64.deb::https://appdownload.m78node.com/download.php?f=linux_deb'
-  'm78-3.0.0-linux-amd64.rpm::https://appdownload.m78node.com/download.php?f=linux_rpm'
+  'm78-3.1.5-linux-amd64.deb::https://appdownload.m78node.com/download.php?f=linux_deb'
   'mqiba-wrapper'
 )
 sha256sums=(
-  '2df141685a8738a0f7df6824982d68dd11649b44b990b7efe270f7ffd4ea208c'
-  '27c368aa7a6fa0d40a543e663b505ce2b0906e312ee9debb989a22aa72ad387e'
+  '2e49cf49d92c7061716c98eb110797ce7d29a29d22b145dd9f0640adcf7825ab'
   'b7a138bac3d85e5e871dbe424d3d138f3cf4ba055260d674ebd23864daf30501'
 )
 
 prepare() {
-  rm -rf deb-archive deb-root rpm-root
-  mkdir -p deb-archive deb-root rpm-root
+  rm -rf deb-archive deb-root
+  mkdir -p deb-archive deb-root
 
-  bsdtar -xf "${srcdir}/m78-3.0.0-linux-amd64.deb" -C "${srcdir}/deb-archive"
+  bsdtar -xf "${srcdir}/m78-3.1.5-linux-amd64.deb" -C "${srcdir}/deb-archive"
   bsdtar -xf "${srcdir}/deb-archive/data.tar.zst" -C "${srcdir}/deb-root"
-  bsdtar -xf "${srcdir}/m78-3.0.0-linux-amd64.rpm" -C "${srcdir}/rpm-root"
 }
 
 package() {
@@ -62,10 +59,6 @@ package() {
 
   if [[ -d "${srcdir}/deb-root/usr/share/icons" ]]; then
     cp -dr --no-preserve=ownership "${srcdir}/deb-root/usr/share/icons" "${pkgdir}/usr/share/"
-  fi
-
-  if [[ -f "${srcdir}/rpm-root/usr/share/pixmaps/mqiba.png" ]]; then
-    install -Dm644 "${srcdir}/rpm-root/usr/share/pixmaps/mqiba.png" "${pkgdir}/usr/share/pixmaps/mqiba.png"
   fi
 
   install -Dm755 "${srcdir}/mqiba-wrapper" "${pkgdir}/usr/bin/mqiba"

--- a/archlinuxcn/m78-bin/lilac.yaml
+++ b/archlinuxcn/m78-bin/lilac.yaml
@@ -1,5 +1,5 @@
 maintainers:
   - github: zxzxzx258
-    email: 25838226+zxzxzx258@users.noreply.github.com
+    email: zxzxzx258@gmail.com
 
 build_prefix: extra-x86_64

--- a/archlinuxcn/m78-bin/lilac.yaml
+++ b/archlinuxcn/m78-bin/lilac.yaml
@@ -1,0 +1,5 @@
+maintainers:
+  - github: zxzxzx258
+    email: 25838226+zxzxzx258@users.noreply.github.com
+
+build_prefix: extra-x86_64

--- a/archlinuxcn/m78-bin/m78-bin.install
+++ b/archlinuxcn/m78-bin/m78-bin.install
@@ -1,0 +1,16 @@
+post_install() {
+  _m78_set_capabilities
+}
+
+post_upgrade() {
+  _m78_set_capabilities
+}
+
+_m78_set_capabilities() {
+  if command -v setcap >/dev/null 2>&1; then
+    setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw=+ep' /usr/lib/mqiba/mqibaCore 2>/dev/null || \
+      echo 'm78-bin: 警告：无法为 /usr/lib/mqiba/mqibaCore 设置网络 capability，网络增强功能可能需要提权。'
+  else
+    echo 'm78-bin: 警告：未找到 setcap，网络增强功能可能需要提权。'
+  fi
+}

--- a/archlinuxcn/m78-bin/m78-bin.install
+++ b/archlinuxcn/m78-bin/m78-bin.install
@@ -1,16 +1,32 @@
 post_install() {
-  _m78_set_capabilities
+  _m78_set_core_privileges
 }
 
 post_upgrade() {
-  _m78_set_capabilities
+  _m78_set_core_privileges
 }
 
-_m78_set_capabilities() {
-  if command -v setcap >/dev/null 2>&1; then
-    setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw=+ep' /usr/lib/mqiba/mqibaCore 2>/dev/null || \
-      echo 'm78-bin: 警告：无法为 /usr/lib/mqiba/mqibaCore 设置网络 capability，网络增强功能可能需要提权。'
-  else
-    echo 'm78-bin: 警告：未找到 setcap，网络增强功能可能需要提权。'
+_m78_set_core_privileges() {
+  core=/usr/lib/mqiba/mqibaCore
+
+  if [ ! -x "${core}" ]; then
+    echo "m78-bin: 警告：未找到 ${core}，无法设置网络权限。"
+    return 0
   fi
+
+  chown root:root "${core}" 2>/dev/null || true
+  chmod 755 "${core}" 2>/dev/null || true
+
+  if command -v setcap >/dev/null 2>&1; then
+    if setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw=+ep' "${core}" 2>/dev/null; then
+      return 0
+    fi
+
+    echo "m78-bin: 警告：无法为 ${core} 设置网络 capability，尝试使用 setuid root 兼容模式。"
+  else
+    echo "m78-bin: 警告：未找到 setcap，尝试使用 setuid root 兼容模式。"
+  fi
+
+  chmod 4755 "${core}" 2>/dev/null || \
+    echo "m78-bin: 警告：无法为 ${core} 设置 setuid root，TUN/路由等网络增强功能可能无法工作。"
 }

--- a/archlinuxcn/m78-bin/mqiba-wrapper
+++ b/archlinuxcn/m78-bin/mqiba-wrapper
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+JVM_LIB_PATHS="/usr/lib/jvm/default-runtime/lib/server:/usr/lib/jvm/java-21-openjdk/lib/server"
+APP_LIB_PATH="/usr/lib/mqiba/lib"
+
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+  export LD_LIBRARY_PATH="${APP_LIB_PATH}:${JVM_LIB_PATHS}:${LD_LIBRARY_PATH}"
+else
+  export LD_LIBRARY_PATH="${APP_LIB_PATH}:${JVM_LIB_PATHS}"
+fi
+
+exec /usr/lib/mqiba/mqiba "$@"


### PR DESCRIPTION
新增 m78-bin，用于打包 M78 官方 x86_64 二进制客户端。

打包说明：

- 使用 appdownload.m78node.com 提供的官方 deb/rpm 下载入口。
- 将应用主体文件安装到 /usr/lib/mqiba。
- 使用 java-runtime-headless 虚拟依赖，已有 JDK/JRE 的系统可以直接满足依赖。
- 使用 patchelf 将上游构建环境中的 RUNPATH 改为 $ORIGIN。
- 安装时为 mqibaCore 设置所需网络能力权限。
