### PR TITLE
tsukimi-git: fix compiling error

### DIFF
--- a/archlinuxcn/tsukimi-git/PKGBUILD
+++ b/archlinuxcn/tsukimi-git/PKGBUILD
@@ -21,6 +21,7 @@ makedepends=(
 	'cargo'
 	'git'
 	'meson'
+	'blueprint-compiler'
 )
 source=(
 	git+https://github.com/tsukinaha/tsukimi.git


### PR DESCRIPTION
This fixes [the compiling error](https://build.archlinuxcn.org/imlonghao-api/pkg/tsukimi-git/log/1784377762) when building v26.7.3
```
  Failed to execute blueprint-compiler for /build/tsukimi-git/src/build/cargo-home/registry/src/index.crates.io-1949cf8c6b5b557f/mutsumi-0.2.0/src/control/menu/menu.blp: No such file or directory (os error 2)
```