### PR TITLE
clash-verge-rev: update service IPC to 2.3.3

### DIFF
--- a/archlinuxcn/clash-verge-rev/PKGBUILD
+++ b/archlinuxcn/clash-verge-rev/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=clash-verge-rev
 _pkgname=${pkgname%-rev}
 pkgver=2.5.2
-_ipc_ver=2.3.0
+_ipc_ver=2.3.3
 pkgrel=1
 pkgdesc="Continuation of Clash Verge | A Clash Meta GUI based on Tauri"
 arch=('x86_64' 'i686' 'aarch64' 'armv7h')
@@ -17,7 +17,7 @@ makedepends=('pnpm' 'rust' 'jq' 'moreutils')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz"
         "${_pkgname}-service-ipc-${_ipc_ver}.tar.gz::https://github.com/${pkgname}/${_pkgname}-service-ipc/archive/v${_ipc_ver}.tar.gz")
 sha512sums=('80c09433a6ac6e4743d9822fd810dc609d92b002ce9aadd13dba3459ee8b09814cf5957be8eb9ffc6066d6fc4f9b3f93468ef431419a0beea845c84bb381e25a'
-            '5c9e316fcd1a8cdf59833be0596cbfb49c7d61445a04ed4cbbc9b5054c37b5f15a53e841c1d4c74b7eae8ff2582172d88e213a1ed3e1eabe6d06437ea4976de9')
+            'd5d4f977eae9bd9e0d91d632034a93d5fb6d8e069032ba8b6ac83a39157f5ca3b45396b837742325f14c5de4db2e4bea638bbd46b6a7b43b43d2b928ff850d2d')
 
 prepare() {
 	pushd "${_pkgname}-service-ipc-${_ipc_ver}/"


### PR DESCRIPTION
## Summary

Update the separately built `clash-verge-service-ipc` sidecars to v2.3.3 so they match the IPC client version locked by Clash Verge Rev v2.5.2.

## Context

The current 2.5.2-1 recipe still builds service IPC v2.3.0, while upstream Clash Verge Rev v2.5.2 uses `clash_verge_service_ipc` v2.3.3. The client compares the service version strictly and therefore repeatedly treats the freshly installed v2.3.0 service as outdated, triggering uninstall/install loops and repeated Polkit authorization prompts.

## Changes

- Update `_ipc_ver` from `2.3.0` to `2.3.3`
- Update the IPC source archive SHA-512 checksum
- Bump `pkgrel` from `1` to `2`

## Testing

- Verified the downloaded v2.3.3 archive SHA-512 checksum
- Ran `bash -n PKGBUILD`
- Ran `makepkg --printsrcinfo` and confirmed the v2.3.3 source and updated checksum
- Confirmed the branch contains one commit changing only `archlinuxcn/clash-verge-rev/PKGBUILD`

## Links

- Reproduction and logs: https://github.com/clash-verge-rev/clash-verge-rev/issues/7540
- Root-cause analysis: https://github.com/clash-verge-rev/clash-verge-rev/issues/7540#issuecomment-5023168952
- Upstream v2.5.2 lockfile: https://github.com/clash-verge-rev/clash-verge-rev/blob/v2.5.2/Cargo.lock#L1210-L1214
- Strict service version check: https://github.com/clash-verge-rev/clash-verge-service-ipc/blob/v2.3.3/src/client/mod.rs#L105-L116