### PR TITLE
chore(candy): remove spdlog and fmt from lilac alpm sources

### DIFF
--- a/alarmcn/candy/lilac.yaml
+++ b/alarmcn/candy/lilac.yaml
@@ -9,10 +9,4 @@ update_on:
   - source: aur
     aur: candy
   - source: alpm
-    alpm: spdlog
-    provided: libspdlog.so
-  - source: alpm
-    alpm: fmt
-    provided: libfmt.so
-  - source: alpm
     alpm: poco

--- a/archlinuxcn/candy/lilac.yaml
+++ b/archlinuxcn/candy/lilac.yaml
@@ -9,10 +9,4 @@ update_on:
   - source: aur
     aur: candy
   - source: alpm
-    alpm: spdlog
-    provided: libspdlog.so
-  - source: alpm
-    alpm: fmt
-    provided: libfmt.so
-  - source: alpm
     alpm: poco


### PR DESCRIPTION
These two libraries have been dropped from candy's dependencies in the latest release, so we no longer need to track them via alpm.