### PR TITLE
apppkg: vcsi

### DIFF
--- a/archlinuxcn/vcsi/PKGBUILD
+++ b/archlinuxcn/vcsi/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Dee.H.Y <dongfengweixiao at hotmail dot com>
+
+pkgname=vcsi
+pkgver=7.0.17
+pkgrel=1
+pkgdesc="Create video contact sheets, thumbnails"
+arch=(any)
+url="https://github.com/amietn/vcsi"
+license=('MIT')
+depends=(python ffmpeg python-numpy python-pillow python-jinja python-texttable ttf-dejavu python-parsedatetime python-setuptools)
+makedepends=(python-installer uv)
+options=(!emptydirs)
+_pkgsrc="$pkgname-$pkgver"
+_pkgext="tar.gz"
+source=("$_pkgsrc.$_pkgext"::"$url/archive/refs/tags/v$pkgver.$_pkgext")
+sha256sums=('5a3c4a9ada7d864c6699fbe9f1a09fc955d1ace29c12026b3f45d8f773e39748')
+
+build() {
+  cd "$_pkgsrc"
+  uv build
+}
+
+package() {
+  cd "$_pkgsrc"
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+}
+

--- a/archlinuxcn/vcsi/lilac.yaml
+++ b/archlinuxcn/vcsi/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: dongfengweixiao
+    email: Dee.H.Y <dongfengweixiao@hotmail.com>
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build: git_pkgbuild_commit
+
+update_on:
+  - source: github
+    github: amietn/vcsi
+    use_latest_release: true
+    prefix: v


### PR DESCRIPTION
PKGBUILD 复制自 aur。

源 PKGBUILD 使用 git 作为源码来源，修改后使用从 tag 获取的压缩包。
移除了源 PKGBUILD 中的所有空字段。

另外，`options=(!emptydirs)` 是否需要移除？