### PR TITLE
millennium: remove options=(debug)

### DIFF
--- a/archlinuxcn/millennium/PKGBUILD
+++ b/archlinuxcn/millennium/PKGBUILD
@@ -10,7 +10,6 @@ makedepends=('git' 'bun' 'curl' 'zip' 'unzip' 'tar' 'cmake' 'ninja' 'rust' 'lib3
 install=millennium.install
 source=("$url/archive/v$pkgver.tar.gz")
 sha256sums=('04c019893842d2647749686bb0f1302ea894be475f7dc25e22bc822254045615')
-options=(debug)
 _pkgdir="Millennium"
 
 prepare() {


### PR DESCRIPTION
Follow upstream to remove options=(debug).

https://github.com/SteamClientHomebrew/Millennium/commit/68b2db077ffd96622f9f9e54988f0011df2ecbf5