### PR TITLE
addpkg: omarchy-auto-theme

### DIFF
--- a/archlinuxcn/omarchy-auto-theme/PKGBUILD
+++ b/archlinuxcn/omarchy-auto-theme/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Jackey <jfdnet@users.noreply.github.com>
+
+pkgname=omarchy-auto-theme
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Auto-switch Omarchy light/dark theme by sunrise/sunset (NOAA solar algorithm)"
+arch=('any')
+url="https://github.com/jfdnet/omarchy-auto-theme"
+license=('MIT')
+depends=('python' 'omarchy')
+optdepends=(
+    'python-dbus: geoclue automatic location'
+    'python-gobject: geoclue automatic location'
+    'geoclue: geoclue automatic location'
+)
+source=("https://github.com/jfdnet/omarchy-auto-theme/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed')
+
+package() {
+    cd "$srcdir/omarchy-auto-theme-$pkgver"
+    make DESTDIR="$pkgdir" PREFIX=/usr install
+}

--- a/archlinuxcn/omarchy-auto-theme/lilac.yaml
+++ b/archlinuxcn/omarchy-auto-theme/lilac.yaml
@@ -1,0 +1,5 @@
+# lilac 构建配置
+# 自动跟随 GitHub release 更新
+pre_build_script: |
+    update_pkgver_and_pkgrel(_G.newver)
+    update_checksums()


### PR DESCRIPTION
## Package

**omarchy-auto-theme** — 按日出日落自动切换 Omarchy 明暗主题

- NOAA 太阳算法计算真实日出日落
- 定位: 手动坐标 > geoclue > IP 回退(带缓存)
- systemd 用户 timer 每 10 分钟检查, 幂等切换
- lilac.yaml 自动跟随 GitHub release 更新

## Files
- `archlinuxcn/omarchy-auto-theme/PKGBUILD`
- `archlinuxcn/omarchy-auto-theme/lilac.yaml`

Source: https://github.com/jfdnet/omarchy-auto-theme