### PR TITLE
addpkg: moonlight-vplus

### DIFF
--- a/archlinuxcn/moonlight-vplus-bin/PKGBUILD
+++ b/archlinuxcn/moonlight-vplus-bin/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: zhicheng233
+
+pkgname=(moonlight-vplus)
+pkgver=6.3.7
+pkgrel=1
+pkgdesc="Moonlight V+ for PC is an enhanced desktop client based on moonlight-stream/moonlight-qt, designed to work closely with Foundation Sunshine."
+arch=(
+    'x86_64'
+    'aarch64'
+)
+url="https://github.com/qiin2333/moonlight-qt"
+license=('GPL-3.0-or-later')
+depends=(
+    'ffmpeg'
+    'libdrm'
+    'libva'
+    'libvdpau'
+    'libxkbcommon'
+    'libglvnd'
+    'libegl'
+    'opus'
+    'sdl2'
+    'sdl2_ttf'
+    'openssl'
+    'qt6-base'
+    'qt6-declarative'
+    'qt6-svg'
+    'qt6-wayland'
+)
+
+makedepends=(
+    'git'
+    'qt6-tools'
+    'vulkan-headers'
+)
+source=(
+    "git+https://github.com/qiin2333/moonlight-qt.git#tag=v${pkgver}"
+    "moonlight-vplus.desktop"
+)
+sha256sums=(
+    'SKIP'
+    'SKIP'
+)
+
+prepare() {
+    cd "$srcdir/moonlight-qt"
+
+    git submodule update --init --recursive
+}
+
+build() {
+    cd "moonlight-qt"
+    qmake6 moonlight-qt.pro
+    make
+}
+
+package_moonlight-vplus() {
+    pkgdesc="Moonlight V+ for PC"
+
+    cd "moonlight-qt"
+
+    install -Dm755 app/moonlight \
+        "$pkgdir/usr/bin/moonlight-vplus"
+
+    install -Dm644 app/moonlight_wix.png \
+        "$pkgdir/usr/share/icons/hicolor/64x64/apps/moonlight-vplus.png"
+
+    install -Dm644 "$srcdir/moonlight-vplus.desktop" \
+        "$pkgdir/usr/share/applications/moonlight-vplus.desktop"
+}

--- a/archlinuxcn/moonlight-vplus-bin/lilac.yaml
+++ b/archlinuxcn/moonlight-vplus-bin/lilac.yaml
@@ -1,0 +1,22 @@
+maintainers:
+		
+  - github: zhicheng233
+		
+    email: mczhicheng@outlook.com
+		
+		
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+		
+post_build_script: git_pkgbuild_commit()
+		
+		
+update_on:
+		
+  - source: github
+		
+    github: https://github.com/qiin2333/moonlight-qt
+		
+    use_latest_release: true
+		
+		
+  - alias: qt6-base

--- a/archlinuxcn/moonlight-vplus-bin/moonlight-vplus.desktop
+++ b/archlinuxcn/moonlight-vplus-bin/moonlight-vplus.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Moonlight VPlus
+Comment=GameStream client for PCs
+Exec=moonlight-vplus
+Icon=moonlight-vplus
+Terminal=false
+Type=Application
+Categories=Game;Network;


### PR DESCRIPTION
新增 moonlight-vplus
[Moonlight V+ for PC](https://github.com/qiin2333/moonlight-qt) 是基于 [moonlight-stream/moonlight-qt](https://github.com/moonlight-stream/moonlight-qt) 维护的增强版桌面客户端，面向搭配 [Foundation Sunshine](https://github.com/qiin2333/Sunshine) 使用的桌面串流场景。

它继续兼容上游 Moonlight / 标准 Sunshine，同时进一步完善 Foundation Sunshine 的客户端体验：能力协商更明确，画质与性能控制更细，串流中的常用操作效率更高。