### PR TITLE
addpkg: omarchy-auto-theme

### DIFF
--- a/archlinuxcn/omarchy-auto-theme/PKGBUILD
+++ b/archlinuxcn/omarchy-auto-theme/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Jackey <jfdnet@users.noreply.github.com>
+
+pkgname=omarchy-auto-theme
+pkgver=1.1.0
+pkgrel=1
+pkgdesc="Auto-switch Omarchy light/dark theme by sunrise/sunset (NOAA solar algorithm)"
+arch=('any')
+url="https://github.com/jfdnet/omarchy-auto-theme"
+license=('MIT')
+depends=('python' 'omarchy')
+optdepends=(
+    'python-dbus: geoclue automatic location'
+    'python-gobject: geoclue automatic location'
+    'geoclue: geoclue automatic location'
+)
+source=("https://github.com/jfdnet/omarchy-auto-theme/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('7125fd41503052340cb6b874451343d9b23cc0ea62edd3c7a93566228b6c0452')
+
+package() {
+    cd "$srcdir/omarchy-auto-theme-$pkgver"
+    make DESTDIR="$pkgdir" PREFIX=/usr install
+}

--- a/archlinuxcn/omarchy-auto-theme/lilac.yaml
+++ b/archlinuxcn/omarchy-auto-theme/lilac.yaml
@@ -1,0 +1,12 @@
+maintainers:
+  - github: jfdnet
+    email: jfdnet@users.noreply.github.com
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build_script: git_pkgbuild_commit()
+
+update_on:
+  - source: github
+    github: jfdnet/omarchy-auto-theme
+    use_latest_release: true
+    prefix: v


### PR DESCRIPTION
A systemd/hypridle-driven tool that auto-switches the Omarchy light/dark theme by real sunrise/sunset (NOAA solar algorithm), with a fixed 08:00/20:00 fallback when location is unavailable, and adopts manually chosen themes as the new light/dark defaults.

Source: https://github.com/jfdnet/omarchy-auto-theme