### PR TITLE
fix(ffnvcodec-13.0): Remove `n` prefix from pkgver

### DIFF
--- a/archlinuxcn/ffnvcodec-headers13.0/lilac.yaml
+++ b/archlinuxcn/ffnvcodec-headers13.0/lilac.yaml
@@ -1,7 +1,7 @@
 maintainers:
   - github: Emojigit
 
-pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+pre_build_script: update_pkgver_and_pkgrel(_G.newver[1:])
 post_build_script: |
   git_pkgbuild_commit()
   update_aur_repo()


### PR DESCRIPTION
Fix <https://build.archlinuxcn.org/imlonghao-api/pkg/ffnvcodec-headers13.0/log/1788293910> and subsequently <https://build.archlinuxcn.org/imlonghao-api/pkg/ffmpeg-nv13.0/log/1788293942>.

@DeepChirp 