### PR TITLE
(no squash) Fixes of ffmpeg-nv13.0

### DIFF
--- a/archlinuxcn/ffmpeg-nv13.0/lilac.yaml
+++ b/archlinuxcn/ffmpeg-nv13.0/lilac.yaml
@@ -1,5 +1,11 @@
 maintainers:
   - github: Emojigit
+
+build_prefix: archlinuxcn-x86_64
+
+repo_depends:
+  - ffnvcodec-headers13.0
+
 update_on:
   - source: alpm
     alpm: ffmpeg

--- a/archlinuxcn/ffmpeg-nv13.0/lilac.yaml
+++ b/archlinuxcn/ffmpeg-nv13.0/lilac.yaml
@@ -1,5 +1,5 @@
 maintainers:
-- github: Emojigit
+  - github: Emojigit
 update_on:
-- source: alpm
-  alpm: ffmpeg
+  - source: alpm
+    alpm: ffmpeg


### PR DESCRIPTION
* style(ffmpeg-nv13.0): lilac.yaml indentations
* fix(ffmpeg-nv13.0): Add build prefix and repo depends<br />Fixes <https://build.archlinuxcn.org/imlonghao-api/pkg/ffmpeg-nv13.0/log/1788338656>

@DeepChirp 