### PR TITLE
fix(pi): add missing chord and server packages for 0.85.0

### DIFF
--- a/archlinuxcn/pi/PKGBUILD
+++ b/archlinuxcn/pi/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Amin Vakil <info AT aminvakil DOT com>
 
 pkgname=pi
-pkgver=0.84.4
-pkgrel=1
+pkgver=0.85.0
+pkgrel=3
 pkgdesc="AI coding agent for the terminal — minimal, extensible and optimized for tool use"
 arch=('x86_64' 'aarch64')
 url="https://github.com/earendil-works/pi"
@@ -17,8 +17,8 @@ optdepends=(
 
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
         "pi-ai-${pkgver}.tgz::https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-${pkgver}.tgz")
-sha256sums=('bf359dd0ded49fd29a884f38240a56d3dbfa7dac3b1c1a9c93112124c75bf72a'
-            'dfd3c929cee5a7387199a0a24dfc1be2096f1ea8f59ffb8285198a0ed01ebf93')
+sha256sums=('8eed537b414b4e04afcc82fe466ec257849638ad40c7bf546fc21cb761e61af4'
+            '46188bdacb555a07466a0111f3963f20932a16199e4d6cfb8d44a7fe5fc6e342')
 
 prepare() {
   rm -rf "${srcdir}/${pkgname}-${pkgver}/packages/ai/src/providers/data"
@@ -51,7 +51,7 @@ package() {
 
   # Copy all necessary files for all packages except coding-agent
   local _pkg
-  for _pkg in ai agent tui telemetry protocol client; do
+  for _pkg in ai agent tui telemetry protocol client chord server; do
     install -dm755 "$pkgdir/$mod_dir/packages/$_pkg"
     cp -a "packages/$_pkg/dist" "packages/$_pkg/package.json" "packages/$_pkg/README.md" \
       "$pkgdir/$mod_dir/packages/$_pkg/"


### PR DESCRIPTION
上游 `pi` 在 `v0.85.0` 中重构拆分出 `@earendil-works/chord` 与 `@earendil-works/server` 子模块。
原 PKGBUILD 的 `package()` 遍历列表中遗漏了这两个目录，导致运行时因缺少模块报错崩溃：
`Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@earendil-works/chord'`