### PR TITLE
add kwin-dpms-per-display

### DIFF
--- a/archlinuxcn/kwin-dpms-per-display/0001-add-setOutputDpmsMode-dbus-method.patch
+++ b/archlinuxcn/kwin-dpms-per-display/0001-add-setOutputDpmsMode-dbus-method.patch
@@ -1,0 +1,72 @@
+--- a/src/org.kde.KWin.xml	2026-05-12 18:26:46.000000000 +0800
++++ b/src/org.kde.KWin.xml	2026-06-01 19:00:42.451971220 +0800
+@@ -41,6 +41,11 @@
+         <annotation name="org.freedesktop.DBus.Method.NoReply" value="true"/>
+         <arg name="showing" type="b" direction="in"/>
+     </method>
++    <method name="setOutputDpmsMode">
++        <arg name="name" type="s" direction="in"/>
++        <arg name="on" type="b" direction="in"/>
++        <arg type="b" direction="out"/>
++    </method>
+     <signal name="showingDesktopChanged">
+         <arg name="showing" type="b" direction="out"/>
+     </signal>
+--- a/src/dbusinterface.h	2026-05-12 18:26:46.000000000 +0800
++++ b/src/dbusinterface.h	2026-06-01 19:00:47.500970503 +0800
+@@ -85,6 +85,16 @@
+      */
+     QVariantMap getWindowInfo(const QString &uuid);
+ 
++    /**
++     * Sets DPMS mode on the specified output by name.
++     * This turns the screen off/on without changing the desktop layout.
++     *
++     * @param name The output name (e.g. "eDP-1", "HDMI-A-1", "DP-6").
++     * @param on true to turn the screen on, false to turn it off.
++     * @return true if the output was found and the change was applied, false otherwise.
++     */
++    bool setOutputDpmsMode(const QString &name, bool on);
++
+     Q_NOREPLY void showDesktop(bool show);
+ 
+ Q_SIGNALS:
+--- a/src/dbusinterface.cpp	2026-05-12 18:26:46.000000000 +0800
++++ b/src/dbusinterface.cpp	2026-06-01 19:00:54.454969245 +0800
+@@ -16,6 +16,8 @@
+ // kwin
+ #include "compositor.h"
+ #include "core/output.h"
++#include "core/outputbackend.h"
++#include "core/outputconfiguration.h"
+ #include "core/renderbackend.h"
+ #include "debug_console.h"
+ #include "kwinadaptor.h"
+@@ -222,6 +224,27 @@
+     Q_EMIT showingDesktopChanged(show);
+ }
+ 
++bool DBusInterface::setOutputDpmsMode(const QString &name, bool on)
++{
++    auto *backend = kwinApp()->outputBackend();
++    if (!backend) {
++        return false;
++    }
++    BackendOutput *output = backend->findOutput(name);
++    if (!output) {
++        return false;
++    }
++
++    OutputConfiguration config;
++    config.source = OutputConfiguration::Source::System;
++    config.changeSet(output)->dpmsMode = on ? BackendOutput::DpmsMode::On : BackendOutput::DpmsMode::Off;
++
++    // Call backend directly instead of Workspace::applyOutputConfiguration,
++    // because the workspace method overrides dpmsMode on ALL outputs with
++    // the global m_dpms state. For per-output DPMS we bypass that.
++    return backend->applyOutputChanges(config) == OutputConfigurationError::None;
++}
++
+ CompositorDBusInterface::CompositorDBusInterface(Compositor *parent)
+     : QObject(parent)
+     , m_compositor(parent)

--- a/archlinuxcn/kwin-dpms-per-display/PKGBUILD
+++ b/archlinuxcn/kwin-dpms-per-display/PKGBUILD
@@ -1,0 +1,114 @@
+# Maintainer: Young Lord <ly-niko@qq.com>
+# Based on the official kwin package. The only difference is the
+# setOutputDpmsMode DBus method for per-output DPMS.
+
+pkgname=kwin-dpms-per-display
+pkgver=6.7.5
+_dirver=$(echo "$pkgver" | cut -d. -f1-3)
+pkgrel=1
+pkgdesc='An easy to use, but flexible, Wayland compositor (with per-output DPMS DBus method)'
+arch=(x86_64)
+url='https://kde.org/plasma-desktop/'
+license=(LGPL-2.0-or-later)
+depends=(aurorae
+         breeze
+         glibc
+         iio-sensor-proxy
+         plasma-activities
+         kauth
+         kcmutils
+         kcolorscheme
+         kconfig
+         kcoreaddons
+         kcrash
+         kdbusaddons
+         kdeclarative
+         kdecoration
+         kglobalaccel
+         kglobalacceld
+         kguiaddons
+         ki18n
+         kidletime
+         kirigami
+         kitemmodels
+         knewstuff
+         knighttime
+         knotifications
+         kpackage
+         kquickcharts
+         kscreenlocker
+         kservice
+         ksvg
+         kwayland
+         kwidgetsaddons
+         kwindowsystem
+         kxmlgui
+         lcms2
+         libcanberra
+         libdisplay-info
+         libdrm
+         libei
+         libepoxy
+         libevdev
+         libgcc
+         libinput
+         libpipewire
+         libqaccessibilityclient-qt6
+         libstdc++
+         libxcb
+         libxcvt
+         libxkbcommon
+         mesa
+         milou
+         pipewire-session-manager
+         libplasma
+         qt6-5compat
+         qt6-base
+         qt6-declarative
+         qt6-svg
+         qt6-tools
+         systemd-libs
+         vulkan-icd-loader
+         wayland
+         xcb-util-keysyms
+         xcb-util-wm)
+makedepends=(extra-cmake-modules
+             kdoctools
+             krunner
+             plasma-wayland-protocols
+             python
+             vulkan-headers
+             wayland-protocols
+             xorg-xwayland)
+optdepends=('plasma-keyboard: virtual keyboard')
+# Drop-in replacement for the official kwin package.
+provides=("kwin=$pkgver")
+conflicts=('kwin')
+# The upstream tarball is named kwin-<ver>, independently of pkgname.
+source=("https://download.kde.org/stable/plasma/$_dirver/kwin-$pkgver.tar.xz"{,.sig}
+        0001-add-setOutputDpmsMode-dbus-method.patch)
+validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
+              '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
+              'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
+              '90A968ACA84537CC27B99EAF2C8DF587A6D4AAC1'  # Nicolas Fella <nicolas.fella@kde.org>
+              '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>
+sha256sums=('6baa910b732d93c48c90f9c1cc685cc93d0b8de0cdf138c24192c045bc3a48e2'
+            'SKIP'
+            '30bf595c645cf80b5c5c8294e5fbd3604c84683f1bc1a8121adbe0733df10dab')
+
+prepare() {
+  cd "kwin-$pkgver"
+  patch -Np1 -i "$srcdir/0001-add-setOutputDpmsMode-dbus-method.patch"
+}
+
+build() {
+  cmake -B build -S "kwin-$pkgver" \
+    -DCMAKE_INSTALL_LIBEXECDIR=lib \
+    -DBUILD_TESTING=OFF
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+  setcap CAP_SYS_NICE=+ep "$pkgdir"/usr/bin/kwin_wayland
+}

--- a/archlinuxcn/kwin-dpms-per-display/PKGBUILD
+++ b/archlinuxcn/kwin-dpms-per-display/PKGBUILD
@@ -1,12 +1,12 @@
-# Maintainer: Young Lord <ly-niko@qq.com>
-# Based on the official kwin package. The only difference is the
-# setOutputDpmsMode DBus method for per-output DPMS.
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Andrea Scarpino <andrea@archlinux.org>
 
 pkgname=kwin-dpms-per-display
 pkgver=6.7.5
-_dirver=$(echo "$pkgver" | cut -d. -f1-3)
-pkgrel=1
-pkgdesc='An easy to use, but flexible, Wayland compositor (with per-output DPMS DBus method)'
+_dirver=$(echo $pkgver | cut -d. -f1-3)
+pkgrel=2
+pkgdesc='An easy to use, but flexible, Wayland compositor'
 arch=(x86_64)
 url='https://kde.org/plasma-desktop/'
 license=(LGPL-2.0-or-later)
@@ -81,28 +81,25 @@ makedepends=(extra-cmake-modules
              wayland-protocols
              xorg-xwayland)
 optdepends=('plasma-keyboard: virtual keyboard')
-# Drop-in replacement for the official kwin package.
 provides=("kwin=$pkgver")
 conflicts=('kwin')
-# The upstream tarball is named kwin-<ver>, independently of pkgname.
-source=("https://download.kde.org/stable/plasma/$_dirver/kwin-$pkgver.tar.xz"{,.sig}
-        0001-add-setOutputDpmsMode-dbus-method.patch)
+source=(https://download.kde.org/stable/plasma/$_dirver/kwin-$pkgver.tar.xz{,.sig} 0001-add-setOutputDpmsMode-dbus-method.patch)
+sha256sums=('6baa910b732d93c48c90f9c1cc685cc93d0b8de0cdf138c24192c045bc3a48e2'
+            'SKIP'
+            '30bf595c645cf80b5c5c8294e5fbd3604c84683f1bc1a8121adbe0733df10dab')
 validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
               '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
               'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
               '90A968ACA84537CC27B99EAF2C8DF587A6D4AAC1'  # Nicolas Fella <nicolas.fella@kde.org>
               '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>
-sha256sums=('6baa910b732d93c48c90f9c1cc685cc93d0b8de0cdf138c24192c045bc3a48e2'
-            'SKIP'
-            '30bf595c645cf80b5c5c8294e5fbd3604c84683f1bc1a8121adbe0733df10dab')
 
 prepare() {
-  cd "kwin-$pkgver"
-  patch -Np1 -i "$srcdir/0001-add-setOutputDpmsMode-dbus-method.patch"
+  cd "$srcdir"/kwin-$pkgver
+  patch -Np1 -i "$srcdir"/0001-add-setOutputDpmsMode-dbus-method.patch
 }
 
 build() {
-  cmake -B build -S "kwin-$pkgver" \
+  cmake -B build  -S kwin-$pkgver \
     -DCMAKE_INSTALL_LIBEXECDIR=lib \
     -DBUILD_TESTING=OFF
   cmake --build build

--- a/archlinuxcn/kwin-dpms-per-display/lilac.py
+++ b/archlinuxcn/kwin-dpms-per-display/lilac.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+from lilaclib import *
+
+g = SimpleNamespace()
+
+_PATCH = '0001-add-setOutputDpmsMode-dbus-method.patch'
+_PATCH_SHA256 = '30bf595c645cf80b5c5c8294e5fbd3604c84683f1bc1a8121adbe0733df10dab'
+
+_EXPECTED = {'pkgname', 'provides', 'source', 'sha256sums', 'prepare', 'renamed'}
+
+
+def pre_build():
+  g.files = download_official_pkgbuild('kwin')
+
+  checks = set()
+  state = 'out'
+  prepare_seen = False
+  for line in edit_file('PKGBUILD'):
+    if line.startswith('pkgname='):
+      line = 'pkgname=kwin-dpms-per-display'
+      checks.add('pkgname')
+
+    elif line.startswith('groups=('):
+      # The official package is in the plasma group; the renamed package must not
+      # join it, it replaces the official package through provides/conflicts.
+      line = "provides=(\"kwin=$pkgver\")\nconflicts=('kwin')"
+      checks.add('provides')
+
+    elif line.startswith('source=('):
+      if line.endswith(')'):
+        line = line.replace(')', ' %s)' % _PATCH)
+        checks.add('source')
+      else:
+        state = 'source'
+
+    elif state == 'source' and line.endswith(')'):
+      line = line.replace(')', ' %s)' % _PATCH)
+      state = 'out'
+      checks.add('source')
+
+    elif line.startswith('sha256sums='):
+      state = 'sha256sums'
+
+    elif state == 'sha256sums' and line.endswith(')'):
+      line = line.replace(')', "\n            '%s')" % _PATCH_SHA256)
+      state = 'out'
+      checks.add('sha256sums')
+
+    elif line.startswith('prepare('):
+      state = 'prepare'
+      prepare_seen = True
+
+    elif state == 'prepare' and line.startswith('}'):
+      line = '  cd "$srcdir"/kwin-$pkgver\n  patch -Np1 -i "$srcdir"/%s\n' % _PATCH + line
+      state = 'out'
+      checks.add('prepare')
+
+    elif line.startswith('build()') and not prepare_seen:
+      # The official PKGBUILD has no prepare(), so add one for the local patch.
+      line = ('prepare() {\n'
+              '  cd "$srcdir"/kwin-$pkgver\n'
+              '  patch -Np1 -i "$srcdir"/%s\n'
+              '}\n\n%s' % (_PATCH, line))
+      checks.add('prepare')
+
+    if '$pkgname' in line:
+      # The upstream tarball is named kwin-<ver>, independently of pkgname.
+      line = line.replace('${pkgname}', 'kwin').replace('$pkgname', 'kwin')
+      checks.add('renamed')
+
+    print(line)
+
+  if checks != _EXPECTED:
+    raise ValueError('official kwin PKGBUILD layout changed, checks=%r' % sorted(checks))
+
+
+def post_build():
+  git_add_files(g.files)
+  git_commit()

--- a/archlinuxcn/kwin-dpms-per-display/lilac.yaml
+++ b/archlinuxcn/kwin-dpms-per-display/lilac.yaml
@@ -1,0 +1,11 @@
+maintainers:
+  - github: Young-Lord
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build_script: git_pkgbuild_commit()
+
+# Rebuild whenever the official kwin package is updated.
+update_on:
+  - source: alpm
+    alpm: kwin
+    strip_release: true

--- a/archlinuxcn/kwin-dpms-per-display/lilac.yaml
+++ b/archlinuxcn/kwin-dpms-per-display/lilac.yaml
@@ -1,11 +1,6 @@
 maintainers:
   - github: Young-Lord
 
-pre_build_script: update_pkgver_and_pkgrel(_G.newver)
-post_build_script: git_pkgbuild_commit()
-
-# Rebuild whenever the official kwin package is updated.
 update_on:
   - source: alpm
     alpm: kwin
-    strip_release: true


### PR DESCRIPTION
## 简述 / Brief Description

kwin 官方包，补丁：新增 `setOutputDpmsMode` DBus 方法，可按输出（显示器）单独开关 DPMS，不改动桌面布局。

用法示例：`qdbus org.kde.KWin /KWin org.kde.KWin.setOutputDpmsMode eDP-1 false`

上游之前有相似的功能，不过被移除了，见 https://bugs.kde.org/show_bug.cgi?id=516784

## 主要语言和工具链 / Main Languages and Toolchains

C++/Qt6/CMake

## 上游链接 / Upstream Link

https://gitlab.archlinux.org/archlinux/packaging/packages/kwin
https://invent.kde.org/plasma/kwin

## 为何需要这个软件包 / Why Need This Package

用来快速关闭/开启特定屏幕的输出，而不改变桌面布局等。