### PR TITLE
add plasma-workspace-calendar-event-location

### DIFF
--- a/archlinuxcn/plasma-workspace-calendar-event-location/0001-calendar-event-location.patch
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/0001-calendar-event-location.patch
@@ -1,0 +1,146 @@
+diff --git a/applets/digital-clock/CalendarView.qml b/applets/digital-clock/CalendarView.qml
+index 6f2ebd891c..561fc3ddd4 100644
+--- a/applets/digital-clock/CalendarView.qml
++++ b/applets/digital-clock/CalendarView.qml
+@@ -261,6 +261,17 @@ PlasmaExtras.Representation {
+                         // Crashes if the type is declared as eventData (which is Q_GADGET)
+                         required property /*PlasmaCalendar.eventData*/var modelData
+ 
++                        // Prefer LOCATION field; fall back to DESCRIPTION (many feeds leave location empty).
++                        readonly property string agendaSubtitle: {
++                            const loc = modelData.location;
++                            const desc = modelData.description;
++                            const lt = loc !== undefined && loc !== null ? String(loc).trim() : "";
++                            if (lt.length > 0) {
++                                return lt;
++                            }
++                            return desc !== undefined && desc !== null ? String(desc).trim() : "";
++                        }
++
+                         width: ListView.view.width
+ 
+                         leftPadding: calendar.paddings
+@@ -268,7 +279,16 @@ PlasmaExtras.Representation {
+                         text: eventTitle.text
+                         hoverEnabled: true
+                         highlighted: ListView.isCurrentItem
+-                        Accessible.description: modelData.description
++                        Accessible.description: {
++                            const parts = [];
++                            if (modelData.location) {
++                                parts.push(modelData.location);
++                            }
++                            if (modelData.description) {
++                                parts.push(modelData.description);
++                            }
++                            return parts.join("; ");
++                        }
+                         readonly property bool hasTime: {
+                             // Explicitly all-day event
+                             if (modelData.isAllDay) {
+@@ -295,7 +315,16 @@ PlasmaExtras.Representation {
+                         }
+ 
+                         PlasmaComponents.ToolTip {
+-                            text: eventItem.modelData.description
++                            text: {
++                                const parts = [];
++                                if (eventItem.modelData.location) {
++                                    parts.push(eventItem.modelData.location);
++                                }
++                                if (eventItem.modelData.description) {
++                                    parts.push(eventItem.modelData.description);
++                                }
++                                return parts.join("\n\n");
++                            }
+                             visible: text !== "" && eventItem.hovered
+                         }
+ 
+@@ -357,19 +386,42 @@ PlasmaExtras.Representation {
+                                 visible: eventItem.hasTime
+                             }
+ 
+-                            PlasmaComponents.Label {
+-                                id: eventTitle
+-
++                            ColumnLayout {
+                                 Layout.row: 0
+                                 Layout.column: 2
++                                Layout.rowSpan: 2
+                                 Layout.fillWidth: true
++                                spacing: 0
+ 
+-                                elide: Text.ElideRight
+-                                text: eventItem.modelData.title
+-                                textFormat: Text.PlainText
+-                                verticalAlignment: Text.AlignVCenter
+-                                maximumLineCount: 2
+-                                wrapMode: Text.Wrap
++                                PlasmaComponents.Label {
++                                    id: eventTitle
++
++                                    Layout.fillWidth: true
++
++                                    elide: Text.ElideRight
++                                    text: eventItem.modelData.title
++                                    textFormat: Text.PlainText
++                                    verticalAlignment: Text.AlignVCenter
++                                    maximumLineCount: 2
++                                    wrapMode: Text.Wrap
++                                }
++
++                                PlasmaComponents.Label {
++                                    id: eventSubtitle
++
++                                    Layout.fillWidth: true
++
++                                    elide: Text.ElideRight
++                                    // NBSP keeps one subtitle line when location/description are empty so rows align.
++                                    text: eventItem.agendaSubtitle.length > 0 ? eventItem.agendaSubtitle : "\u00a0"
++                                    textFormat: Text.PlainText
++                                    font.pointSize: Math.max(1, Math.round(Kirigami.Theme.defaultFont.pointSize * 0.85))
++                                    font.family: Kirigami.Theme.defaultFont.family
++                                    opacity: 0.75
++                                    maximumLineCount: 2
++                                    wrapMode: Text.Wrap
++                                    Accessible.ignored: eventItem.agendaSubtitle.length === 0
++                                }
+                             }
+                         }
+                     }
+diff --git a/components/calendar/eventdatadecorator.cpp b/components/calendar/eventdatadecorator.cpp
+index c210455831..58faaf4e25 100644
+--- a/components/calendar/eventdatadecorator.cpp
++++ b/components/calendar/eventdatadecorator.cpp
+@@ -43,6 +43,11 @@ QString EventDataDecorator::description() const
+     return m_data.description();
+ }
+ 
++QString EventDataDecorator::location() const
++{
++    return m_data.location();
++}
++
+ QString EventDataDecorator::eventType() const
+ {
+     switch (m_data.type()) {
+diff --git a/components/calendar/eventdatadecorator.h b/components/calendar/eventdatadecorator.h
+index 27c4a91f3b..e8dc333a0e 100644
+--- a/components/calendar/eventdatadecorator.h
++++ b/components/calendar/eventdatadecorator.h
+@@ -23,6 +23,7 @@ class EventDataDecorator
+     Q_PROPERTY(bool isMinor READ isMinor CONSTANT FINAL)
+     Q_PROPERTY(QString title READ title CONSTANT FINAL)
+     Q_PROPERTY(QString description READ description CONSTANT FINAL)
++    Q_PROPERTY(QString location READ location CONSTANT FINAL)
+     Q_PROPERTY(QString eventColor READ eventColor CONSTANT FINAL)
+     Q_PROPERTY(QString eventType READ eventType CONSTANT FINAL)
+ 
+@@ -36,6 +37,7 @@ public:
+     bool isMinor() const;
+     QString title() const;
+     QString description() const;
++    QString location() const;
+     QString eventType() const;
+     QString eventColor() const;
+ 

--- a/archlinuxcn/plasma-workspace-calendar-event-location/PKGBUILD
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/PKGBUILD
@@ -1,13 +1,13 @@
-# Maintainer: Young Lord <ly-niko@qq.com>
-# Based on the official plasma-workspace package, plus the Digital Clock agenda
-# location patch (EventDataDecorator.location + agenda subtitle). Requires the
-# upstream kdeclarative location API (KF >= 6.27).
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Andrea Scarpino <andrea@archlinux.org>
+# Contributor: Alexey D. <lq07829icatm at rambler.ru>
 
 pkgname=plasma-workspace-calendar-event-location
 pkgver=6.7.5
-_dirver=$(echo "$pkgver" | cut -d. -f1-3)
-pkgrel=1
-pkgdesc='KDE Plasma Workspace (with calendar event location in the Digital Clock agenda)'
+_dirver=$(echo $pkgver | cut -d. -f1-3)
+pkgrel=2
+pkgdesc='KDE Plasma Workspace'
 arch=(x86_64)
 url='https://kde.org/plasma-desktop/'
 license=(LGPL-2.0-or-later)
@@ -90,7 +90,6 @@ depends=(accountsservice
          ocean-sound-theme
          plasma-activities
          plasma-activities-stats
-         plasma-integration
          prison
          qt6-5compat
          qt6-base
@@ -118,7 +117,32 @@ makedepends=(baloo
              networkmanager-qt
              plasma-wayland-protocols
              qcoro)
-optdepends=('appmenu-gtk-module: global menu support for some GTK3 applications'
+provides=("plasma-workspace=$pkgver")
+conflicts=('plasma-workspace')
+source=(https://download.kde.org/stable/plasma/$_dirver/plasma-workspace-$pkgver.tar.xz{,.sig} 0001-calendar-event-location.patch)
+sha256sums=('94ab21e2243b7876f65c315f1e545081c6437f5bd0a041ca4fb6c2533ae874c9'
+            'SKIP'
+            '67d42d95af431cd63c2de82b9c75c9015ccc0d67f9e9377f59ff868b8cd9ec6f')
+validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
+              '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
+              'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
+              '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>
+
+prepare() {
+  cd "$srcdir"/plasma-workspace-$pkgver
+  patch -Np1 -i "$srcdir"/0001-calendar-event-location.patch
+}
+
+build() {
+  cmake -B build -S plasma-workspace-$pkgver \
+    -DCMAKE_INSTALL_LIBEXECDIR=lib \
+    -DGLIBC_LOCALE_GEN=OFF \
+    -DBUILD_TESTING=OFF
+  cmake --build build
+}
+
+package() {
+  optdepends=('appmenu-gtk-module: global menu support for some GTK3 applications'
             'baloo: Baloo search runner'
             'discover: manage applications installation from the launcher'
             'kdepim-addons: displaying PIM events in the calendar'
@@ -128,35 +152,13 @@ optdepends=('appmenu-gtk-module: global menu support for some GTK3 applications'
             'plasma-workspace-wallpapers: additional wallpapers'
             'plasma5-integration: use Plasma settings in Qt5 applications'
             'xdg-desktop-portal-gtk: sync font settings to Flatpak apps')
-# Drop-in replacement for the official plasma-workspace package.
-provides=("plasma-workspace=$pkgver")
-conflicts=('plasma-workspace')
-# The upstream tarball is named plasma-workspace-<ver>, independently of pkgname.
-source=(https://download.kde.org/stable/plasma/$_dirver/plasma-workspace-$pkgver.tar.xz{,.sig}
-        0001-calendar-event-location.patch)
-validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
-              '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
-              'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
-              '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>
-sha256sums=('94ab21e2243b7876f65c315f1e545081c6437f5bd0a041ca4fb6c2533ae874c9'
-            'SKIP'
-            '67d42d95af431cd63c2de82b9c75c9015ccc0d67f9e9377f59ff868b8cd9ec6f')
+  depends+=(plasma-integration) # Declare runtime dependency here to avoid dependency cycles at build time
+  conflicts+=(plasma-wayland-session)
+  replaces=(plasma-wayland-session)
 
-prepare() {
-  cd "plasma-workspace-$pkgver"
-  patch -Np1 -i "$srcdir/0001-calendar-event-location.patch"
-}
-
-build() {
-  cmake -B build -S "plasma-workspace-$pkgver" \
-    -DCMAKE_INSTALL_LIBEXECDIR=lib \
-    -DGLIBC_LOCALE_GEN=OFF \
-    -DBUILD_TESTING=OFF
-  cmake --build build
-}
-
-package() {
   DESTDIR="$pkgdir" cmake --install build
-  # plasmax11.desktop is shipped by the separate plasma-x11-session package.
+
   rm -r "$pkgdir"/usr/share/xsessions/plasmax11.desktop
 }
+
+

--- a/archlinuxcn/plasma-workspace-calendar-event-location/PKGBUILD
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/PKGBUILD
@@ -1,0 +1,162 @@
+# Maintainer: Young Lord <ly-niko@qq.com>
+# Based on the official plasma-workspace package, plus the Digital Clock agenda
+# location patch (EventDataDecorator.location + agenda subtitle). Requires the
+# upstream kdeclarative location API (KF >= 6.27).
+
+pkgname=plasma-workspace-calendar-event-location
+pkgver=6.7.5
+_dirver=$(echo "$pkgver" | cut -d. -f1-3)
+pkgrel=1
+pkgdesc='KDE Plasma Workspace (with calendar event location in the Digital Clock agenda)'
+arch=(x86_64)
+url='https://kde.org/plasma-desktop/'
+license=(LGPL-2.0-or-later)
+depends=(accountsservice
+         appstream-qt
+         dbus
+         fontconfig
+         freetype2
+         glibc
+         icu
+         kactivitymanagerd
+         karchive
+         kauth
+         kbookmarks
+         kcmutils
+         kcolorscheme
+         kcompletion
+         kconfig
+         kconfigwidgets
+         kcoreaddons
+         kcrash
+         kde-cli-tools
+         kdeclarative
+         kded
+         kdbusaddons
+         kglobalaccel
+         kguiaddons
+         kholidays
+         ki18n
+         kiconthemes
+         kidletime
+         kio
+         kio-extras
+         kio-fuse
+         kirigami
+         kirigami-addons
+         kitemmodels
+         kjobwidgets
+         knewstuff
+         knighttime
+         knotifications
+         kpackage
+         kparts
+         kpipewire
+         krunner
+         kquickcharts
+         kscreenlocker
+         kservice
+         kstatusnotifieritem
+         ksvg
+         ksystemstats
+         ktexteditor
+         ktextwidgets
+         kuserfeedback
+         kwallet
+         kwayland
+         kwidgetsaddons
+         kwin
+         kwindowsystem
+         kxmlgui
+         layer-shell-qt
+         libcanberra
+         libice
+         libgcc
+         libkexiv2
+         libksysguard
+         libplasma
+         libqalculate
+         libsm
+         libstdc++
+         libx11
+         libxau
+         libxcb
+         libxcrypt
+         libxcursor
+         libxfixes
+         libxft
+         libxtst
+         milou
+         ocean-sound-theme
+         plasma-activities
+         plasma-activities-stats
+         plasma-integration
+         prison
+         qt6-5compat
+         qt6-base
+         qt6-declarative
+         qt6-location
+         qt6-positioning
+         qt6-svg
+         qt6-tools # for qdbus
+         qt6-virtualkeyboard
+         sh
+         solid
+         systemd-libs
+         wayland
+         xcb-util
+         xcb-util-cursor
+         xcb-util-image
+         xcb-util-wm
+         xorg-xmessage
+         xorg-xrdb
+         xorg-xwayland
+         zlib)
+makedepends=(baloo
+             extra-cmake-modules
+             kdoctools
+             networkmanager-qt
+             plasma-wayland-protocols
+             qcoro)
+optdepends=('appmenu-gtk-module: global menu support for some GTK3 applications'
+            'baloo: Baloo search runner'
+            'discover: manage applications installation from the launcher'
+            'kdepim-addons: displaying PIM events in the calendar'
+            'kwayland-integration: Wayland integration for Qt5 applications'
+            'kwin-x11: X session window manager'
+            'networkmanager-qt: IP based geolocation'
+            'plasma-workspace-wallpapers: additional wallpapers'
+            'plasma5-integration: use Plasma settings in Qt5 applications'
+            'xdg-desktop-portal-gtk: sync font settings to Flatpak apps')
+# Drop-in replacement for the official plasma-workspace package.
+provides=("plasma-workspace=$pkgver")
+conflicts=('plasma-workspace')
+# The upstream tarball is named plasma-workspace-<ver>, independently of pkgname.
+source=(https://download.kde.org/stable/plasma/$_dirver/plasma-workspace-$pkgver.tar.xz{,.sig}
+        0001-calendar-event-location.patch)
+validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
+              '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
+              'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
+              '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>
+sha256sums=('94ab21e2243b7876f65c315f1e545081c6437f5bd0a041ca4fb6c2533ae874c9'
+            'SKIP'
+            '67d42d95af431cd63c2de82b9c75c9015ccc0d67f9e9377f59ff868b8cd9ec6f')
+
+prepare() {
+  cd "plasma-workspace-$pkgver"
+  patch -Np1 -i "$srcdir/0001-calendar-event-location.patch"
+}
+
+build() {
+  cmake -B build -S "plasma-workspace-$pkgver" \
+    -DCMAKE_INSTALL_LIBEXECDIR=lib \
+    -DGLIBC_LOCALE_GEN=OFF \
+    -DBUILD_TESTING=OFF
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+  # plasmax11.desktop is shipped by the separate plasma-x11-session package.
+  rm -r "$pkgdir"/usr/share/xsessions/plasmax11.desktop
+}

--- a/archlinuxcn/plasma-workspace-calendar-event-location/lilac.py
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/lilac.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+from lilaclib import *
+
+g = SimpleNamespace()
+
+_PATCH = '0001-calendar-event-location.patch'
+_PATCH_SHA256 = '67d42d95af431cd63c2de82b9c75c9015ccc0d67f9e9377f59ff868b8cd9ec6f'
+
+_EXPECTED = {'pkgbase', 'pkgname', 'provides', 'source', 'sha256sums', 'prepare',
+             'mainpkg', 'drop-x11', 'renamed'}
+
+
+def pre_build():
+  g.files = download_official_pkgbuild('plasma-workspace')
+
+  checks = set()
+  state = 'out'
+  prepare_seen = False
+  for line in edit_file('PKGBUILD'):
+    if state == 'skip-pkgfn':
+      # Drop package_plasma-x11-session() entirely: plasmax11.desktop stays with
+      # the separate official plasma-x11-session package.
+      if line == '}':
+        state = 'out'
+      continue
+
+    if line.startswith('pkgbase='):
+      # Fold the split package into a single one.
+      checks.add('pkgbase')
+      continue
+
+    if line.startswith('pkgname=('):
+      line = 'pkgname=plasma-workspace-calendar-event-location'
+      checks.add('pkgname')
+
+    elif line.startswith('groups=('):
+      # The official package is in the plasma group; the renamed package must not
+      # join it, it replaces the official package through provides/conflicts.
+      line = "provides=(\"plasma-workspace=$pkgver\")\nconflicts=('plasma-workspace')"
+      checks.add('provides')
+
+    elif line.startswith('source=('):
+      if line.endswith(')'):
+        line = line.replace(')', ' %s)' % _PATCH)
+        checks.add('source')
+      else:
+        state = 'source'
+
+    elif state == 'source' and line.endswith(')'):
+      line = line.replace(')', ' %s)' % _PATCH)
+      state = 'out'
+      checks.add('source')
+
+    elif line.startswith('sha256sums='):
+      state = 'sha256sums'
+
+    elif state == 'sha256sums' and line.endswith(')'):
+      line = line.replace(')', "\n            '%s')" % _PATCH_SHA256)
+      state = 'out'
+      checks.add('sha256sums')
+
+    elif line.startswith('prepare('):
+      state = 'prepare'
+      prepare_seen = True
+
+    elif state == 'prepare' and line.startswith('}'):
+      line = '  cd "$srcdir"/plasma-workspace-$pkgver\n  patch -Np1 -i "$srcdir"/%s\n' % _PATCH + line
+      state = 'out'
+      checks.add('prepare')
+
+    elif line.startswith('build()') and not prepare_seen:
+      # The official PKGBUILD has no prepare(), so add one for the local patch.
+      line = ('prepare() {\n'
+              '  cd "$srcdir"/plasma-workspace-$pkgver\n'
+              '  patch -Np1 -i "$srcdir"/%s\n'
+              '}\n\n%s' % (_PATCH, line))
+      checks.add('prepare')
+
+    elif line.startswith('package_plasma-workspace()'):
+      line = 'package() {'
+      checks.add('mainpkg')
+
+    elif line.startswith('package_plasma-x11-session()'):
+      state = 'skip-pkgfn'
+      checks.add('drop-x11')
+      continue
+
+    elif line.strip().startswith('conflicts=('):
+      # Keep the provides/conflicts set at the top level above.
+      line = line.replace('conflicts=(', 'conflicts+=(', 1)
+
+    if '$pkgname' in line:
+      # The upstream tarball is named plasma-workspace-<ver>, independently of pkgname.
+      line = line.replace('${pkgname}', 'plasma-workspace').replace('$pkgname', 'plasma-workspace')
+      checks.add('renamed')
+
+    print(line)
+
+  if checks != _EXPECTED:
+    raise ValueError('official plasma-workspace PKGBUILD layout changed, checks=%r' % sorted(checks))
+
+
+def post_build():
+  git_add_files(g.files)
+  git_commit()

--- a/archlinuxcn/plasma-workspace-calendar-event-location/lilac.yaml
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/lilac.yaml
@@ -1,11 +1,6 @@
 maintainers:
   - github: Young-Lord
 
-pre_build_script: update_pkgver_and_pkgrel(_G.newver)
-post_build_script: git_pkgbuild_commit()
-
-# Rebuild whenever the official plasma-workspace package is updated.
 update_on:
   - source: alpm
     alpm: plasma-workspace
-    strip_release: true

--- a/archlinuxcn/plasma-workspace-calendar-event-location/lilac.yaml
+++ b/archlinuxcn/plasma-workspace-calendar-event-location/lilac.yaml
@@ -1,0 +1,11 @@
+maintainers:
+  - github: Young-Lord
+
+pre_build_script: update_pkgver_and_pkgrel(_G.newver)
+post_build_script: git_pkgbuild_commit()
+
+# Rebuild whenever the official plasma-workspace package is updated.
+update_on:
+  - source: alpm
+    alpm: plasma-workspace
+    strip_release: true


### PR DESCRIPTION
## 简述 / Brief Description

plasma-workspace 官方包，其中“数字时钟”小部件的日程列表显示事件地点，而非上游的事件备注。事件备注仍然可以通过鼠标悬浮在事件上查看。

## 主要语言和工具链 / Main Languages and Toolchains

C++/QML/CMake

## 上游链接 / Upstream Link

https://gitlab.archlinux.org/archlinux/packaging/packages/plasma-workspace
https://invent.kde.org/plasma/plasma-workspace

## 为何需要这个软件包 / Why Need This Package

用来快速查看地点。